### PR TITLE
UX: suppressing summary panel

### DIFF
--- a/assets/javascripts/discourse/widgets/discourse-reactions-list.js.es6
+++ b/assets/javascripts/discourse/widgets/discourse-reactions-list.js.es6
@@ -8,8 +8,13 @@ export default createWidget("discourse-reactions-list", {
 
   html(attrs) {
     const reactions = attrs.post.reactions;
+    const currentUserReaction = attrs.post.current_user_reaction;
 
     if (attrs.post.reaction_users_count <= 0) {
+      return;
+    }
+
+    if(currentUserReaction && reactions.length == 1 && reactions[0].id == currentUserReaction.id) {
       return;
     }
 

--- a/assets/javascripts/discourse/widgets/discourse-reactions-list.js.es6
+++ b/assets/javascripts/discourse/widgets/discourse-reactions-list.js.es6
@@ -14,7 +14,7 @@ export default createWidget("discourse-reactions-list", {
       return;
     }
 
-    if(currentUserReaction && reactions.length == 1 && reactions[0].id == currentUserReaction.id) {
+    if(currentUserReaction && reactions.length == 1) {
       return;
     }
 


### PR DESCRIPTION
suppressing summary panel when there's only one reaction and the current user has the used the same reaction