### PR TITLE
DEV: Limit reaction_users to 27

### DIFF
--- a/assets/javascripts/discourse/widgets/discourse-reactions-actions.js.es6
+++ b/assets/javascripts/discourse/widgets/discourse-reactions-actions.js.es6
@@ -317,6 +317,11 @@ export default createWidget("discourse-reactions-actions", {
           return false;
         } else if (reaction.id === post.current_user_reaction.id) {
           post.reactions[index].count -= 1;
+          const users = post.reactions[index].users;
+          users.splice(
+            users.indexOf(users.findBy("username", "ahmedgagan6")),
+            1
+          );
           return false;
         }
 
@@ -334,7 +339,7 @@ export default createWidget("discourse-reactions-actions", {
       post.reactions.every((reaction, index) => {
         if (reaction.id === attrs.reaction) {
           post.reactions[index].count += 1;
-          post.reactions[index].users.push({
+          post.reactions[index].users.unshift({
             username: this.currentUser.username,
             avatar_template: this.currentUser.avatar_template,
             can_undo: true

--- a/assets/javascripts/discourse/widgets/discourse-reactions-actions.js.es6
+++ b/assets/javascripts/discourse/widgets/discourse-reactions-actions.js.es6
@@ -426,7 +426,18 @@ export default createWidget("discourse-reactions-actions", {
     }
 
     if (current_user_reaction && current_user_reaction.id == attrs.reaction) {
-      return this.toggleReaction(attrs);
+      this.toggleReaction(attrs);
+      return CustomReaction.toggle(this.attrs.post.id, attrs.reaction)
+        .then(resolve)
+        .catch(e => {
+          bootbox.alert(this.extractErrors(e));
+
+          post.current_user_reaction = current_user_reaction;
+          post.current_user_used_main_reaction = current_user_used_main_reaction;
+          post.reactions = reactions;
+          post.reaction_users_count = reaction_users_count;
+          this.scheduleRerender();
+        });
     }
 
     if (

--- a/assets/javascripts/discourse/widgets/discourse-reactions-actions.js.es6
+++ b/assets/javascripts/discourse/widgets/discourse-reactions-actions.js.es6
@@ -318,10 +318,9 @@ export default createWidget("discourse-reactions-actions", {
         } else if (reaction.id === post.current_user_reaction.id) {
           post.reactions[index].count -= 1;
           const users = post.reactions[index].users;
-          users.splice(
-            users.indexOf(users.findBy("username", "ahmedgagan6")),
-            1
-          );
+          const userIndex = users.indexOf(users.findBy("username", this.currentUser.username));
+          users.splice(userIndex, 1);
+
           return false;
         }
 
@@ -428,7 +427,6 @@ export default createWidget("discourse-reactions-actions", {
     if (current_user_reaction && current_user_reaction.id == attrs.reaction) {
       this.toggleReaction(attrs);
       return CustomReaction.toggle(this.attrs.post.id, attrs.reaction)
-        .then(resolve)
         .catch(e => {
           bootbox.alert(this.extractErrors(e));
 

--- a/assets/javascripts/discourse/widgets/discourse-reactions-state-panel-reaction.js.es6
+++ b/assets/javascripts/discourse/widgets/discourse-reactions-state-panel-reaction.js.es6
@@ -17,6 +17,8 @@ export default createWidget("discourse-reactions-state-panel-reaction", {
 
   html(attrs) {
     const elements = [];
+    const MAX_USERS_COUNT = 26;
+    const MIN_USERS_COUNT = 8;
 
     elements.push(
       h("div.reaction-wrapper", [
@@ -29,14 +31,14 @@ export default createWidget("discourse-reactions-state-panel-reaction", {
       ])
     );
 
-    const list = attrs.reaction.users.slice(0, 8).map(user =>
+    const list = attrs.reaction.users.slice(0, MIN_USERS_COUNT).map(user =>
       avatarFor("tiny", {
         username: user.username,
         template: user.avatar_template
       })
     );
 
-    if (attrs.reaction.users.length > 8) {
+    if (attrs.reaction.users.length > MIN_USERS_COUNT) {
       list.push(
         this.attach("button", {
           action: "showUsers",
@@ -52,7 +54,7 @@ export default createWidget("discourse-reactions-state-panel-reaction", {
 
     if (attrs.isDisplayed) {
       list.push(
-        attrs.reaction.users.slice(8, 26).map(user =>
+        attrs.reaction.users.slice(MIN_USERS_COUNT, MAX_USERS_COUNT).map(user =>
           avatarFor("tiny", {
             username: user.username,
             template: user.avatar_template
@@ -62,9 +64,9 @@ export default createWidget("discourse-reactions-state-panel-reaction", {
     }
 
     let more;
-    if (attrs.isDisplayed && attrs.reaction.users.length > 26) {
+    if (attrs.isDisplayed && attrs.reaction.count > MAX_USERS_COUNT) {
       more = I18n.t("discourse_reactions.state_panel.more_users", {
-        count: attrs.reaction.users.length - 26
+        count: attrs.reaction.count - MAX_USERS_COUNT
       });
     }
 

--- a/assets/javascripts/discourse/widgets/discourse-reactions-state-panel-reaction.js.es6
+++ b/assets/javascripts/discourse/widgets/discourse-reactions-state-panel-reaction.js.es6
@@ -6,6 +6,9 @@ import { createWidget } from "discourse/widgets/widget";
 import { avatarFor } from "discourse/widgets/post";
 import { iconNode } from "discourse-common/lib/icon-library";
 
+const MAX_USERS_COUNT = 26;
+const MIN_USERS_COUNT = 8;
+
 export default createWidget("discourse-reactions-state-panel-reaction", {
   tagName: "div.discourse-reactions-state-panel-reaction",
 
@@ -17,8 +20,6 @@ export default createWidget("discourse-reactions-state-panel-reaction", {
 
   html(attrs) {
     const elements = [];
-    const MAX_USERS_COUNT = 26;
-    const MIN_USERS_COUNT = 8;
 
     elements.push(
       h("div.reaction-wrapper", [

--- a/plugin.rb
+++ b/plugin.rb
@@ -15,6 +15,8 @@ register_asset 'stylesheets/mobile/discourse-reactions.scss', :mobile
 register_svg_icon 'fas fa-star'
 register_svg_icon 'far fa-star'
 
+MAX_USERS_COUNT = 26
+
 after_initialize do
   SeedFu.fixture_paths << Rails.root.join("plugins", "discourse-reactions", "db", "fixtures").to_s
 
@@ -62,8 +64,6 @@ after_initialize do
   end
 
   add_to_serializer(:post, :reactions) do
-    MAX_USERS_COUNT = 26
-
     reactions = object.reactions.select { |reaction| reaction[:reaction_users_count] }.map do |reaction|
       {
         id: reaction.reaction_value,

--- a/plugin.rb
+++ b/plugin.rb
@@ -68,7 +68,7 @@ after_initialize do
       {
         id: reaction.reaction_value,
         type: reaction.reaction_type.to_sym,
-        users: reaction.reaction_users.order("discourse_reactions_reaction_users.created_at desc").limit(MAX_USERS_COUNT).map { |reaction_user| { username: reaction_user.username, avatar_template: reaction_user.avatar_template, can_undo: reaction_user.can_undo? } },
+        users: reaction.reaction_users.order("discourse_reactions_reaction_users.created_at desc").limit(MAX_USERS_COUNT + 1).map { |reaction_user| { username: reaction_user.username, avatar_template: reaction_user.avatar_template, can_undo: reaction_user.can_undo? } },
         count: reaction.reaction_users_count
       }
     end

--- a/plugin.rb
+++ b/plugin.rb
@@ -62,12 +62,13 @@ after_initialize do
   end
 
   add_to_serializer(:post, :reactions) do
+    MAX_USERS_COUNT = 26
 
     reactions = object.reactions.select { |reaction| reaction[:reaction_users_count] }.map do |reaction|
       {
         id: reaction.reaction_value,
         type: reaction.reaction_type.to_sym,
-        users: reaction.reaction_users.map { |reaction_user| { username: reaction_user.username, avatar_template: reaction_user.avatar_template, can_undo: reaction_user.can_undo? } },
+        users: reaction.reaction_users.order("discourse_reactions_reaction_users.created_at desc").limit(MAX_USERS_COUNT).map { |reaction_user| { username: reaction_user.username, avatar_template: reaction_user.avatar_template, can_undo: reaction_user.can_undo? } },
         count: reaction.reaction_users_count
       }
     end


### PR DESCRIPTION
@jjaffeux Did 27 here because
- when I drop a reaction, in the reaction-state-panel if there are users more than say 53, it should display `26 and 27 others...` but the issue here is I dropped a reaction which means 1 user is removed from 26 and it displays 25 users instead of 26.