### PR TITLE
FIX: Handled ReacordNotUnique error

### DIFF
--- a/app/controllers/discourse_reactions/custom_reactions_controller.rb
+++ b/app/controllers/discourse_reactions/custom_reactions_controller.rb
@@ -12,7 +12,14 @@ module DiscourseReactions
       end
 
       publish_change_to_clients!(post)
-      DiscourseReactions::ReactionManager.new(reaction_value: params[:reaction], user: current_user, guardian: guardian, post: post).toggle!
+
+      begin
+        DiscourseReactions::ReactionManager.new(reaction_value: params[:reaction], user: current_user, guardian: guardian, post: post).toggle!
+      rescue ActiveRecord::RecordNotUnique
+        # If the user already performed this action, it's proably due to a different browser tab
+        # or non-debounced clicking. We can ignore.
+      end
+
       post.publish_change_to_clients!(:acted)
 
       render_json_dump(post_serializer(post).as_json)


### PR DESCRIPTION
Sorry for the multiple PR. It was due to some issue, now it's fixed.
@jjaffeux can you suggest to me how to write the spec for this? As it's not defined when will the backend raise this issue, I removed this recuse block and fired 20 requests together in a spec file but all requests were successful. Also, I checked out in the core there's no spec for this type of ignoring rescue block.

![Screenshot 2021-03-10 at 12 54 09 PM](https://user-images.githubusercontent.com/35112518/110593872-2166c380-81a2-11eb-9700-648a18bc14e6.png)
