### PR TITLE
FIX: Message bus will load both dropped and new reacted reaction

### DIFF
--- a/app/controllers/discourse_reactions/custom_reactions_controller.rb
+++ b/app/controllers/discourse_reactions/custom_reactions_controller.rb
@@ -115,10 +115,19 @@ module DiscourseReactions
     end
 
     def publish_change_to_clients!(post)
+      reactions = [params[:reaction]]
+      reaction_user = DiscourseReactions::ReactionUser.find_by(user_id: current_user.id, post_id: post.id)
+
+      if reaction_user
+        reaction = DiscourseReactions::Reaction.find(reaction_user.reaction_id)
+        reactions.push(reaction.reaction_value)
+      end
+
       message = {
         id: post.id,
-        type: params[:reaction]
+        type: reactions
       }
+
       MessageBus.publish("/post/#{post.id}", message)
     end
 

--- a/assets/javascripts/discourse/widgets/discourse-reactions-counter.js.es6
+++ b/assets/javascripts/discourse/widgets/discourse-reactions-counter.js.es6
@@ -28,9 +28,11 @@ export default createWidget("discourse-reactions-counter", {
     this.unsubscribe();
 
     MessageBus.subscribe(`/post/${this.attrs.post.id}`, data => {
-      if (this.state[data.type].length) {
-        this.getUsers(data.type);
-      }
+      data.type.forEach(reaction => {
+        if (this.state[reaction].length) {
+          this.getUsers(reaction);
+        }
+      });
     });
   },
 


### PR DESCRIPTION
@jjaffeux This will load reaction_users of both dropped and newly added reaction. Also, reason behind keeping the message bus before reaction is, we want both reaction values, the one which will be dropped and the one which will be added. so if we keep it after the `toggle` we won't be able to get which reaction was dropped here. thoughts?