### PR TITLE
DEV: Front-end sorting of reactions when adding a new reaction to list

### DIFF
--- a/assets/javascripts/discourse/widgets/discourse-reactions-actions.js.es6
+++ b/assets/javascripts/discourse/widgets/discourse-reactions-actions.js.es6
@@ -369,17 +369,19 @@ export default createWidget("discourse-reactions-actions", {
           count: 1
         };
 
-        const tempReactions = Object.assign([], post.reactions,);
+        const tempReactions = Object.assign([], post.reactions);
 
         tempReactions.push(newReaction);
 
-        const newReactionIndex = tempReactions.sort((reaction1, reaction2) =>
-          reaction2.count - reaction1.count || reaction1.id > reaction2.id
-            ? 1
-            : reaction2.id > reaction1.id
-            ? -1
-            : 0
-        ).indexOf(newReaction);
+        const newReactionIndex = tempReactions
+          .sort((reaction1, reaction2) =>
+            reaction2.count - reaction1.count || reaction1.id > reaction2.id
+              ? 1
+              : reaction2.id > reaction1.id
+              ? -1
+              : 0
+          )
+          .indexOf(newReaction);
 
         post.reactions.splice(newReactionIndex, 0, newReaction);
       }

--- a/assets/javascripts/discourse/widgets/discourse-reactions-actions.js.es6
+++ b/assets/javascripts/discourse/widgets/discourse-reactions-actions.js.es6
@@ -373,14 +373,16 @@ export default createWidget("discourse-reactions-actions", {
 
         tempReactions.push(newReaction);
 
+        //sorts reactions and get index of new reaction
         const newReactionIndex = tempReactions
-          .sort((reaction1, reaction2) =>
-            reaction2.count - reaction1.count || reaction1.id > reaction2.id
-              ? 1
-              : reaction2.id > reaction1.id
-              ? -1
-              : 0
-          )
+          .sort((reaction1, reaction2) => {
+            if (reaction1.count > reaction2.count) return -1;
+            if (reaction1.count < reaction2.count) return 1;
+
+            //if count is same, sort it by id
+            if (reaction1.id > reaction2.id) return 1;
+            if (reaction1.id < reaction2.id) return -1;
+          })
           .indexOf(newReaction);
 
         post.reactions.splice(newReactionIndex, 0, newReaction);

--- a/assets/javascripts/discourse/widgets/discourse-reactions-actions.js.es6
+++ b/assets/javascripts/discourse/widgets/discourse-reactions-actions.js.es6
@@ -246,7 +246,11 @@ export default createWidget("discourse-reactions-actions", {
       }
 
       const pickedReaction = document.querySelector(
-        `[data-post-id="${params.postId}"] .discourse-reactions-picker .pickable-reaction.${CSS.escape(params.reaction)} .emoji`
+        `[data-post-id="${
+          params.postId
+        }"] .discourse-reactions-picker .pickable-reaction.${CSS.escape(
+          params.reaction
+        )} .emoji`
       );
 
       const scales = [1.0, 1.75];
@@ -359,11 +363,27 @@ export default createWidget("discourse-reactions-actions", {
       });
 
       if (!isAvailable) {
-        post.reactions.push({
+        const newReaction = {
           id: attrs.reaction,
           type: "emoji",
           count: 1
-        });
+        };
+
+        const tempReactions = Object.assign([], post.reactions,);
+
+        tempReactions.push(newReaction);
+
+        tempReactions.sort((reaction1, reaction2) =>
+          reaction2.count - reaction1.count || reaction1.id > reaction2.id
+            ? 1
+            : reaction2.id > reaction1.id
+            ? -1
+            : 0
+        );
+
+        const newReactionIndex = tempReactions.indexOf(newReaction);
+
+        post.reactions.splice(newReactionIndex, 0, newReaction);
       }
 
       if (!post.current_user_reaction) {

--- a/assets/javascripts/discourse/widgets/discourse-reactions-actions.js.es6
+++ b/assets/javascripts/discourse/widgets/discourse-reactions-actions.js.es6
@@ -373,15 +373,13 @@ export default createWidget("discourse-reactions-actions", {
 
         tempReactions.push(newReaction);
 
-        tempReactions.sort((reaction1, reaction2) =>
+        const newReactionIndex = tempReactions.sort((reaction1, reaction2) =>
           reaction2.count - reaction1.count || reaction1.id > reaction2.id
             ? 1
             : reaction2.id > reaction1.id
             ? -1
             : 0
-        );
-
-        const newReactionIndex = tempReactions.indexOf(newReaction);
+        ).indexOf(newReaction);
 
         post.reactions.splice(newReactionIndex, 0, newReaction);
       }


### PR DESCRIPTION
@jjaffeux 

Here, I've added front-end sorting only when adding a new reaction to the list, because IMO all other cases just shifts position of reaction which looks nice and this case seems weird because first we add a reaction to the list, and then sorting is done.