### PR TITLE
UX: make defaults be positive and encourage constructive criticism

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -10,7 +10,7 @@ discourse_reactions:
     default: "heart"
   discourse_reactions_enabled_reactions:
     type: list
-    default: laughing|open_mouth|cry|angry|hugs
+    default: thumbsup|clap|heart|bulb|thinking
     client: true
   discourse_reactions_desaturated_reaction_panel:
     default: false


### PR DESCRIPTION
Let's promote more positivity and less negative reactions by default. These can be overridden but I can't see this as a bad idea to have. 