### PR TITLE
FIX: When post.likeAction is null do not error or show reactions for deleted posts

### DIFF
--- a/assets/javascripts/discourse/widgets/discourse-reactions-reaction-button.js.es6
+++ b/assets/javascripts/discourse/widgets/discourse-reactions-reaction-button.js.es6
@@ -59,7 +59,7 @@ export default createWidget("discourse-reactions-reaction-button", {
   buildAttributes(attrs) {
     const likeAction = attrs.post.likeAction;
     if (!likeAction) {
-      return;
+      return {};
     }
 
     let title;

--- a/assets/javascripts/initializers/discourse-reactions.js.es6
+++ b/assets/javascripts/initializers/discourse-reactions.js.es6
@@ -13,7 +13,7 @@ function initializeDiscourseReactions(api) {
   api.decorateWidget("post-menu:before-extra-controls", dec => {
     const post = dec.getModel();
 
-    if (!post) {
+    if (!post || !post.likeAction) {
       return;
     }
 
@@ -33,7 +33,7 @@ function initializeDiscourseReactions(api) {
       dec.widget.siteSettings.discourse_reactions_reaction_for_like;
     const post = dec.getModel();
 
-    if (!post) {
+    if (!post || !post.likeAction) {
       return;
     }
 


### PR DESCRIPTION
We should not show the reactions for deleted posts where likeAction is null; this is the behaviour of Likes in core.

Also fixes issue caused in https://github.com/discourse/discourse-reactions/commit/08fb397d481e59903b87a069f2f2e18a004bb772. Because we have an early return if `likeAction` is null, `this.buildAttributes(attrs).title` would error.