### PR TITLE
DEV: Fixes enum & post_serializer_spec test

### DIFF
--- a/lib/reaction_for_like_site_setting_enum.rb
+++ b/lib/reaction_for_like_site_setting_enum.rb
@@ -10,8 +10,8 @@ class ReactionForLikeSiteSettingEnum < EnumSiteSetting
   end
 
   def self.values
-    @values ||= begin
-      reactions = SiteSetting.discourse_reactions_enabled_reactions.split('|').map do |reaction|
+    @values = begin
+      reactions = DiscourseReactions::Reaction.valid_reactions.map do |reaction|
         { name: reaction, value: reaction }
       end
 

--- a/lib/reaction_for_like_site_setting_enum.rb
+++ b/lib/reaction_for_like_site_setting_enum.rb
@@ -3,8 +3,6 @@
 require_dependency 'enum_site_setting'
 
 class ReactionForLikeSiteSettingEnum < EnumSiteSetting
-  HEART ||= 'heart'
-
   def self.valid_value?(val)
     values.any? { |v| v[:value] == val }
   end
@@ -14,8 +12,6 @@ class ReactionForLikeSiteSettingEnum < EnumSiteSetting
       reactions = DiscourseReactions::Reaction.valid_reactions.map do |reaction|
         { name: reaction, value: reaction }
       end
-
-      [{ name: HEART, value: HEART }].concat(reactions)
     end
   end
 end

--- a/spec/serializers/post_serializer_spec.rb
+++ b/spec/serializers/post_serializer_spec.rb
@@ -19,7 +19,7 @@ describe PostSerializer do
 
   before do
     SiteSetting.post_undo_action_window_mins = 10
-    SiteSetting.discourse_reactions_enabled_reactions = '-otter|thumbsup'
+    SiteSetting.discourse_reactions_enabled_reactions = 'otter|thumbsup'
     SiteSetting.discourse_reactions_like_icon = 'heart'
   end
 


### PR DESCRIPTION
@jjaffeux Now the validation won't fail, `DiscourseReactions::Reaction.valid_reactions` always haves the value of `discourse_reactions_reaction_for_like` setting in it.