### PR TITLE
DEV: Allows '-1' types of reaction

### DIFF
--- a/app/models/discourse_reactions/reaction.rb
+++ b/app/models/discourse_reactions/reaction.rb
@@ -17,7 +17,7 @@ module DiscourseReactions
     def self.valid_reactions
       Set[
         DiscourseReactions::Reaction.main_reaction_id,
-        *SiteSetting.discourse_reactions_enabled_reactions.split(/\|-?/)
+        *SiteSetting.discourse_reactions_enabled_reactions.split("|")
       ]
     end
 

--- a/spec/models/reaction_spec.rb
+++ b/spec/models/reaction_spec.rb
@@ -5,7 +5,7 @@ require_relative '../fabricators/reaction_fabricator.rb'
 
 describe DiscourseReactions::Reaction do
   it 'knows which reactions are valid' do
-    SiteSetting.discourse_reactions_enabled_reactions = "laughing|heart|-open_mouth|-cry|-angry|thumbsup|-thumbsdown"
+    SiteSetting.discourse_reactions_enabled_reactions = "laughing|heart|open_mouth|cry|angry|thumbsup|thumbsdown"
     expect(described_class.valid_reactions).to eq(%w(laughing heart open_mouth cry angry thumbsup thumbsdown).to_set)
   end
 end

--- a/spec/serializers/topic_view_serializer_spec.rb
+++ b/spec/serializers/topic_view_serializer_spec.rb
@@ -20,7 +20,7 @@ describe TopicViewSerializer do
 
     it 'shows valid reactions and user reactions' do
       SiteSetting.discourse_reactions_like_icon = "heart"
-      SiteSetting.discourse_reactions_enabled_reactions = "laughing|heart|-open_mouth|-cry|-angry|thumbsup|-thumbsdown"
+      SiteSetting.discourse_reactions_enabled_reactions = "laughing|heart|open_mouth|cry|angry|thumbsup|thumbsdown"
       json = TopicViewSerializer.new(topic_view, scope: Guardian.new(user_1), root: false).as_json
       expect(json[:valid_reactions]).to eq(%w(laughing heart open_mouth cry angry thumbsup thumbsdown).to_set)
       expect(json[:post_stream][:posts][0][:reactions]).to eq(


### PR DESCRIPTION
@jjaffeux when there was a `-1` in the list. this regex used to remove `-` and that caused the 422 error.
Now, as we are using emoji-picker we can directly split the string from "|"