### PR TITLE
PERF: Fix N+1 queries when viewing a topic.

### DIFF
--- a/lib/discourse_reactions/topic_view_serializer_extension.rb
+++ b/lib/discourse_reactions/topic_view_serializer_extension.rb
@@ -3,7 +3,10 @@
 module DiscourseReactions::TopicViewSerializerExtension
   def posts
     if SiteSetting.discourse_reactions_enabled
-      posts = object.posts.includes(:post_actions, reactions: { reaction_users: :user })
+      posts = object.posts
+        .includes(:post_actions, reactions: { reaction_users: :user })
+        .to_a
+
       post_ids = posts.map(&:id).uniq
 
       posts_reaction_users_count = TopicViewSerializer.posts_reaction_users_count(post_ids)


### PR DESCRIPTION
This is a revert of 30e424e3b6d5c482093c4c95c4ca83c80f7eb357 which
incorrectly removed the eagar loading that has been done in the
TopicViewSerializerMixin.

Follow-up to 30e424e3b6d5c482093c4c95c4ca83c80f7eb357