### PR TITLE
FIX: attempts to make clicks more correct

### DIFF
--- a/assets/javascripts/discourse/widgets/discourse-reactions-counter.js.es6
+++ b/assets/javascripts/discourse/widgets/discourse-reactions-counter.js.es6
@@ -89,6 +89,19 @@ export default createWidget("discourse-reactions-counter", {
 
   click(event) {
     if (!this.capabilities.touch || !this.site.mobileView) {
+      event.stopPropagation();
+
+      // in case we lost sync due to another widget not in the same tree
+      // collapsing the panel, we attempt to reconciliate from DOM state
+      const container = document.getElementById(this.buildId(this.attrs));
+      if (
+        !container
+          .querySelector(".discourse-reactions-state-panel")
+          .classList.contains("is-expanded")
+      ) {
+        this.state.statePanelExpanded = false;
+      }
+
       if (!this.state.statePanelExpanded) {
         this.getUsers();
       }

--- a/assets/javascripts/discourse/widgets/discourse-reactions-state-panel-reaction.js.es6
+++ b/assets/javascripts/discourse/widgets/discourse-reactions-state-panel-reaction.js.es6
@@ -18,6 +18,15 @@ export default createWidget("discourse-reactions-state-panel-reaction", {
     }
   },
 
+  click(event) {
+    if (event?.target?.classList?.contains("show-users")) {
+      event.preventDefault();
+      event.stopPropagation();
+
+      this.sendWidgetAction("showUsers", this.attrs?.reaction?.id);
+    }
+  },
+
   html(attrs) {
     const elements = [];
 
@@ -42,15 +51,10 @@ export default createWidget("discourse-reactions-state-panel-reaction", {
 
     if (attrs.users.length > MIN_USERS_COUNT) {
       list.push(
-        this.attach("button", {
-          action: "showUsers",
-          contents: [
-            iconNode(attrs.isDisplayed ? "chevron-up" : "chevron-down"),
-          ],
-          actionParam: attrs,
-          className: "show-users",
-          title: "",
-        })
+        h(
+          "button.show-users",
+          iconNode(attrs.isDisplayed ? "chevron-up" : "chevron-down")
+        )
       );
     }
 

--- a/assets/javascripts/discourse/widgets/discourse-reactions-state-panel.js.es6
+++ b/assets/javascripts/discourse/widgets/discourse-reactions-state-panel.js.es6
@@ -30,13 +30,13 @@ export default createWidget("discourse-reactions-state-panel", {
     }
   },
 
-  showUsers(attrs) {
+  showUsers(reactionId) {
     if (!this.state.displayedReactionId) {
-      this.state.displayedReactionId = attrs.reaction.id;
-    } else if (this.state.displayedReactionId === attrs.reaction.id) {
+      this.state.displayedReactionId = reactionId;
+    } else if (this.state.displayedReactionId === reactionId) {
       this.hideUsers();
-    } else if (this.state.displayedReactionId !== attrs.reaction.id) {
-      this.state.displayedReactionId = attrs.reaction.id;
+    } else if (this.state.displayedReactionId !== reactionId) {
+      this.state.displayedReactionId = reactionId;
     }
   },
 
@@ -69,6 +69,6 @@ export default createWidget("discourse-reactions-state-panel", {
         )
       : h("div.spinner-container", h("div.spinner"));
 
-    return [, h("div.container", reactions)];
+    return h("div.container", reactions);
   },
 });

--- a/assets/stylesheets/common/discourse-reactions.scss
+++ b/assets/stylesheets/common/discourse-reactions.scss
@@ -303,6 +303,7 @@ html.discourse-reactions-no-select {
     .d-icon {
       color: var(--primary-medium) !important;
       margin: 0;
+      pointer-events: none;
     }
   }
 


### PR DESCRIPTION
Due to various minor issues and one major one, it could sometimes be very easy to close the panel, or very hard to open it.

The biggest issues is related to how during dev we decided to let various reactions parts be in different widgets trees, which makes global state complicated.

I have various ideas to make it better, but I think we should first attempt to move everything (visually and in code) into one widget tree. I will first try to make this accepted, before going into complex refactors.