### PR TITLE
FIX: do not return deleted posts in my-reactions

### DIFF
--- a/app/controllers/discourse_reactions/custom_reactions_controller.rb
+++ b/app/controllers/discourse_reactions/custom_reactions_controller.rb
@@ -28,7 +28,8 @@ module DiscourseReactions
 
     def my_reactions
       reaction_users = DiscourseReactions::ReactionUser
-        .joins(:reaction)
+        .joins(:reaction, :post)
+        .includes(:user, :post, :reaction)
         .where(user_id: current_user.id)
         .where('discourse_reactions_reactions.reaction_users_count IS NOT NULL')
 

--- a/spec/requests/custom_reactions_controller_spec.rb
+++ b/spec/requests/custom_reactions_controller_spec.rb
@@ -119,6 +119,29 @@ describe DiscourseReactions::CustomReactionsController do
       expect(parsed[0]['post']['user']['id']).to eq(user_1.id)
       expect(parsed[0]['reaction']['id']).to eq(reaction_1.id)
     end
+
+    context 'a topic containing a post with one of your reactions has been deleted' do
+      fab!(:deleted_post) { Fabricate(:post) }
+      fab!(:kept_post) { Fabricate(:post) }
+      fab!(:user) { Fabricate(:user) }
+      fab!(:reaction_on_deleted_post) { Fabricate(:reaction, post: deleted_post, reaction_value: "laughing") }
+      fab!(:reaction_on_kept_post) { Fabricate(:reaction, post: kept_post, reaction_value: "laughing") }
+      fab!(:reaction_user_on_deleted_post) { Fabricate(:reaction_user, reaction: reaction_on_deleted_post, user: user, post: deleted_post) }
+      fab!(:reaction_user_on_kept_post) { Fabricate(:reaction_user, reaction: reaction_on_kept_post, user: user, post: kept_post) }
+
+      it 'doesn’t return the deleted post/reaction' do
+        sign_in(user)
+
+        deleted_post.topic.destroy!
+        # deleted_post.reload
+
+        get "/discourse-reactions/posts/my-reactions.json"
+        parsed = response.parsed_body
+
+        expect(parsed.length).to eq(1)
+        expect(parsed[0]['post_id']).to eq(kept_post.id)
+      end
+    end
   end
 
   context '#reactions_received' do

--- a/spec/requests/custom_reactions_controller_spec.rb
+++ b/spec/requests/custom_reactions_controller_spec.rb
@@ -132,6 +132,10 @@ describe DiscourseReactions::CustomReactionsController do
       it 'doesn’t return the deleted post/reaction' do
         sign_in(user)
 
+        get "/discourse-reactions/posts/my-reactions.json"
+        parsed = response.parsed_body
+        expect(parsed.length).to eq(2)
+
         PostDestroyer.new(Discourse.system_user, deleted_post).destroy
 
         get "/discourse-reactions/posts/my-reactions.json"

--- a/spec/requests/custom_reactions_controller_spec.rb
+++ b/spec/requests/custom_reactions_controller_spec.rb
@@ -132,8 +132,7 @@ describe DiscourseReactions::CustomReactionsController do
       it 'doesn’t return the deleted post/reaction' do
         sign_in(user)
 
-        deleted_post.topic.destroy!
-        # deleted_post.reload
+        PostDestroyer.new(Discourse.system_user, deleted_post).destroy
 
         get "/discourse-reactions/posts/my-reactions.json"
         parsed = response.parsed_body

--- a/spec/requests/custom_reactions_controller_spec.rb
+++ b/spec/requests/custom_reactions_controller_spec.rb
@@ -120,7 +120,7 @@ describe DiscourseReactions::CustomReactionsController do
       expect(parsed[0]['reaction']['id']).to eq(reaction_1.id)
     end
 
-    context 'a topic containing a post with one of your reactions has been deleted' do
+    context 'a post with one of your reactions has been deleted' do
       fab!(:deleted_post) { Fabricate(:post) }
       fab!(:kept_post) { Fabricate(:post) }
       fab!(:user) { Fabricate(:user) }


### PR DESCRIPTION
This was causing an error on frontend when reaching for `/u/:username/activity/my-reactions` :

```
TypeError: Cannot read property 'topic' of null
```