### PR TITLE
FIX: show reactions given/received by other users

### DIFF
--- a/assets/javascripts/discourse/controllers/user-activity-my-reactions.js.es6
+++ b/assets/javascripts/discourse/controllers/user-activity-my-reactions.js.es6
@@ -23,7 +23,7 @@ export default Controller.extend({
 
     const opts = { beforeReactionUserId };
 
-    CustomReaction.findReactions(this.reactionsUrl, opts)
+    CustomReaction.findReactions(this.reactionsUrl, this.username, opts)
       .then((newReactionUsers) => {
         reactionUsers.addObjects(newReactionUsers);
         if (newReactionUsers.length === 0) {

--- a/assets/javascripts/discourse/models/discourse-reactions-custom-reaction.js.es6
+++ b/assets/javascripts/discourse/models/discourse-reactions-custom-reaction.js.es6
@@ -21,10 +21,9 @@ CustomReaction.reopenClass({
     );
   },
 
-  findReactions(url, opts) {
+  findReactions(url, username, opts) {
     opts = opts || {};
-
-    const data = {};
+    const data = { username };
 
     if (opts.beforeReactionUserId) {
       data.before_reaction_user_id = opts.beforeReactionUserId;

--- a/assets/javascripts/discourse/routes/user-activity-my-reactions.js.es6
+++ b/assets/javascripts/discourse/routes/user-activity-my-reactions.js.es6
@@ -3,7 +3,10 @@ import CustomReaction from "../models/discourse-reactions-custom-reaction";
 
 export default DiscourseRoute.extend({
   model() {
-    return CustomReaction.findReactions("my-reactions");
+    return CustomReaction.findReactions(
+      "my-reactions",
+      this.modelFor("user").get("username")
+    );
   },
 
   setupController(controller, model) {
@@ -12,6 +15,7 @@ export default DiscourseRoute.extend({
       model,
       canLoadMore: !loadedAll,
       reactionsUrl: "my-reactions",
+      username: this.modelFor("user").get("username"),
     });
     this.controllerFor("application").set("showFooter", loadedAll);
   },

--- a/assets/javascripts/discourse/routes/user-notifications-reactions-received.js.es6
+++ b/assets/javascripts/discourse/routes/user-notifications-reactions-received.js.es6
@@ -3,7 +3,10 @@ import CustomReaction from "../models/discourse-reactions-custom-reaction";
 
 export default DiscourseRoute.extend({
   model() {
-    return CustomReaction.findReactions("reactions-received");
+    return CustomReaction.findReactions(
+      "reactions-received",
+      this.modelFor("user").get("username")
+    );
   },
 
   setupController(controller, model) {
@@ -12,6 +15,7 @@ export default DiscourseRoute.extend({
       model,
       canLoadMore: !loadedAll,
       reactionsUrl: "reactions-received",
+      username: this.modelFor("user").get("username"),
     });
     this.controllerFor("application").set("showFooter", loadedAll);
   },

--- a/spec/requests/custom_reactions_controller_spec.rb
+++ b/spec/requests/custom_reactions_controller_spec.rb
@@ -108,10 +108,10 @@ describe DiscourseReactions::CustomReactionsController do
   end
 
   context '#my_reactions' do
-    it 'returns reactions i did to others posts' do
-      sign_in(user_2)
+    it 'returns reactions given by a user' do
+      sign_in(user_1)
 
-      get "/discourse-reactions/posts/my-reactions.json"
+      get "/discourse-reactions/posts/my-reactions.json", params: { username: user_2.username }
       parsed = response.parsed_body
 
       expect(parsed[0]['user']['id']).to eq(user_2.id)
@@ -132,13 +132,13 @@ describe DiscourseReactions::CustomReactionsController do
       it 'doesn’t return the deleted post/reaction' do
         sign_in(user)
 
-        get "/discourse-reactions/posts/my-reactions.json"
+        get "/discourse-reactions/posts/my-reactions.json", params: { username: user.username }
         parsed = response.parsed_body
         expect(parsed.length).to eq(2)
 
         PostDestroyer.new(Discourse.system_user, deleted_post).destroy
 
-        get "/discourse-reactions/posts/my-reactions.json"
+        get "/discourse-reactions/posts/my-reactions.json", params: { username: user.username }
         parsed = response.parsed_body
 
         expect(parsed.length).to eq(1)
@@ -148,10 +148,10 @@ describe DiscourseReactions::CustomReactionsController do
   end
 
   context '#reactions_received' do
-    it 'returns reactions other people did to my posts' do
-      sign_in(user_1)
+    it 'returns reactions received by a user' do
+      sign_in(user_2)
 
-      get "/discourse-reactions/posts/reactions-received.json"
+      get "/discourse-reactions/posts/reactions-received.json", params: { username: user_1.username }
       parsed = response.parsed_body
 
       expect(parsed[0]['user']['id']).to eq(user_3.id)


### PR DESCRIPTION
Meta ref: https://meta.discourse.org/t/i-can-only-see-my-reactions/202198