### PR TITLE
FIX: Don't include invalid emojis in post reactions field.

### DIFF
--- a/lib/discourse_reactions/post_extension.rb
+++ b/lib/discourse_reactions/post_extension.rb
@@ -6,4 +6,10 @@ module DiscourseReactions::PostExtension
     base.has_many :reactions_user, class_name: 'DiscourseReactions::ReactionUser'
     base.attr_accessor :user_positively_reacted, :reaction_users_count
   end
+
+  def emoji_reactions
+    @emoji_reactions ||= begin
+      self.reactions.select { |reaction| Emoji.exists?(reaction.reaction_value) }
+    end
+  end
 end

--- a/plugin.rb
+++ b/plugin.rb
@@ -67,7 +67,7 @@ after_initialize do
   end
 
   add_to_serializer(:post, :reactions) do
-    reactions = object.reactions.select { |reaction| reaction[:reaction_users_count] }.map do |reaction|
+    reactions = object.emoji_reactions.select { |reaction| reaction[:reaction_users_count] }.map do |reaction|
       {
         id: reaction.reaction_value,
         type: reaction.reaction_type.to_sym,
@@ -97,7 +97,8 @@ after_initialize do
 
   add_to_serializer(:post, :current_user_reaction) do
     return nil unless scope.user.present?
-    object.reactions.each do |reaction|
+
+    object.emoji_reactions.each do |reaction|
       reaction_user = reaction.reaction_users.find { |ru| ru.user_id == scope.user.id }
 
       next unless reaction_user


### PR DESCRIPTION
Including emojis that are no longer valid will result in the client side
rendering code blowing up.