### PR TITLE
FIX: Post expanding in activity stream was causing reload

### DIFF
--- a/assets/javascripts/discourse/models/discourse-reactions-custom-reaction.js.es6
+++ b/assets/javascripts/discourse/models/discourse-reactions-custom-reaction.js.es6
@@ -2,6 +2,7 @@ import { ajax } from "discourse/lib/ajax";
 import RestModel from "discourse/models/rest";
 import Topic from "discourse/models/topic";
 import User from "discourse/models/user";
+import Post from "discourse/models/post";
 import Category from "discourse/models/category";
 import EmberObject from "@ember/object";
 
@@ -37,6 +38,7 @@ CustomReaction.reopenClass({
         reaction.topic = Topic.create(reaction.post.topic);
         reaction.post_user = User.create(reaction.post.user);
         reaction.category = Category.findById(reaction.post.category_id);
+        reaction.post = Post.create(reaction.post);
         return EmberObject.create(reaction);
       });
     });

--- a/assets/javascripts/discourse/templates/components/discourse-reactions-reaction-post.hbs
+++ b/assets/javascripts/discourse/templates/components/discourse-reactions-reaction-post.hbs
@@ -17,7 +17,7 @@
 
 <div class="excerpt">
   {{#if reaction.post.expandedExcerpt}}
-    {{html-safe post.expandedExcerpt}}
+    {{html-safe reaction.post.expandedExcerpt}}
   {{else}}
     {{html-safe reaction.post.excerpt}}
   {{/if}}


### PR DESCRIPTION
When clicking on the expand arrow in the reactions activity
stream, a full page reload occurred because core calls:

```
const postNumber = item.get("post_number");
```

Where item is reaction.post. However, reaction.post had not been
converted to an Ember object via the Post model, so .get caused
an error, which triggered the reload. This commit fixes the issue
by making sure that reaction.post is an instance of Post model,
and also fixes an error in the discourse-reactions-reaction-post
template not showing the correct expanded content when the activity
is expanded.

See https://meta.discourse.org/t/user-stream-item-posts-expand-issue/208037