### PR TITLE
FEATURE: Collapse multiple reactions to the same post.

### DIFF
--- a/app/services/discourse_reactions/reaction_notification.rb
+++ b/app/services/discourse_reactions/reaction_notification.rb
@@ -13,16 +13,6 @@ module DiscourseReactions
 
       return if post_user.user_option.like_notification_frequency == UserOption.like_notification_frequency_type[:never]
 
-      last_notification = post_user.notifications
-        .order("notifications.id DESC")
-        .find_by(
-          topic_id: @post.topic_id,
-          post_number: @post.post_number,
-          notification_type: Notification.types[:reaction]
-        )
-
-      return if (last_notification && !enabled_reaction_notifications?(post_user, last_notification))
-
       PostAlerter.new.create_notification(post_user, Notification.types[:reaction], @post, user_id: @user.id, display_username: @user.username)
     end
 
@@ -42,13 +32,6 @@ module DiscourseReactions
     end
 
     private
-
-    def enabled_reaction_notifications?(user, notification)
-      return true if user.user_option.like_notification_frequency == UserOption.like_notification_frequency_type[:always]
-      return true if user.user_option.like_notification_frequency == UserOption.like_notification_frequency_type[:first_time_and_daily] && notification.created_at < 1.day.ago
-      return true if user.user_option.like_notification_frequency == UserOption.like_notification_frequency_type[:first_time] && notification
-      false
-    end
 
     def reaction_usernames
       @post.reactions

--- a/assets/javascripts/discourse/widgets/discourse-reactions-reaction-notification-item.js.es6
+++ b/assets/javascripts/discourse/widgets/discourse-reactions-reaction-notification-item.js.es6
@@ -13,9 +13,23 @@ createWidgetFrom(DefaultNotificationItem, "reaction-notification-item", {
   },
 
   text(_notificationName, data) {
-    const reactionsCount = data.count;
+    const count = data.count;
+    const username = formatUsername(data.display_username);
 
-    if (!reactionsCount || reactionsCount === 1) {
+    if (data.username2) {
+      const othersCount = count - 2;
+      const notificationKey =
+        othersCount === 0 ? "reaction_2" : "reaction_many";
+
+      return I18n.t(`notifications.${notificationKey}`, {
+        username,
+        username2: formatUsername(data.username2),
+        description: this.attrs.fancy_title,
+        count: othersCount,
+      });
+    }
+
+    if (!count || count === 1) {
       return I18n.t("notifications.reaction.single", {
         username: formatUsername(data.display_username),
         description: this.attrs.fancy_title,
@@ -23,7 +37,7 @@ createWidgetFrom(DefaultNotificationItem, "reaction-notification-item", {
     } else {
       return I18n.t("notifications.reaction.multiple", {
         username: formatUsername(data.display_username),
-        count: reactionsCount,
+        count,
       });
     }
   },

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -26,6 +26,9 @@ en:
       reaction: 
         single: "<span>%{username}</span> %{description}"
         multiple: "<span>%{username}</span> reacted to %{count} of your posts"
-      reaction_2: "<span>%{username}, %{username2}</span> %{description}"
+      reaction_2: "<span class='double-user'>%{username}, %{username2}</span> %{description}"
+      reaction_many:
+        one: "<span class='multi-user'>%{username}, %{username2} and %{count} other</span> %{description}"
+        other: "<span class='multi-user'>%{username}, %{username2} and %{count} others</span> %{description}"
       titles:
         reaction: "new reaction"


### PR DESCRIPTION
When users have their like frequency set to `always`, we collapse multiple reaction notifications when users react to the same post. With this change, we reach feature parity between reactions and likes.