### PR TITLE
FIX: Keep the heart icon if all the collapsed reactions were likes.

### DIFF
--- a/assets/javascripts/discourse/widgets/discourse-reactions-reaction-notification-item.js.es6
+++ b/assets/javascripts/discourse/widgets/discourse-reactions-reaction-notification-item.js.es6
@@ -16,7 +16,7 @@ createWidgetFrom(DefaultNotificationItem, "reaction-notification-item", {
     let reactionName = this.attrs.data.reaction_icon;
     let icon;
 
-    if (reactionName && !this.attrs.data.username2) {
+    if (reactionName) {
       icon = iconNode(reactionName);
     } else {
       icon = iconNode(`notification.${notificationName}`);

--- a/plugin.rb
+++ b/plugin.rb
@@ -277,11 +277,18 @@ after_initialize do
         data = notification.data_hash
         if existing_notification_of_same_type
           same_type_data = existing_notification_of_same_type.data_hash
-          data.merge(
+
+          new_data = data.merge(
             previous_notification_id: existing_notification_of_same_type.id,
             username2: same_type_data[:display_username],
             count: (same_type_data[:count] || 1).to_i + 1
           )
+
+          if new_data[:reaction_icon] != same_type_data[:reaction_icon]
+            new_data.delete(:reaction_icon)
+          end
+
+          new_data
         else
           data
         end


### PR DESCRIPTION
When collapsing reactions to the same post because the user has the like frequency set to always, we still display the heart icon if all were are likes.