### PR TITLE
FIX: Filter reactions when clicking a consolidated notification.

### DIFF
--- a/app/controllers/discourse_reactions/custom_reactions_controller.rb
+++ b/app/controllers/discourse_reactions/custom_reactions_controller.rb
@@ -71,6 +71,12 @@ module DiscourseReactions
           .where('discourse_reactions_reaction_users.id < ?', params[:before_post_id].to_i)
       end
 
+      if params[:acting_username]
+        reaction_users = reaction_users
+          .joins(:user)
+          .where(users: { username: params[:acting_username] })
+      end
+
       reaction_users = reaction_users
         .order(created_at: :desc)
         .limit(20)

--- a/assets/javascripts/discourse/controllers/user-activity-reactions.js.es6
+++ b/assets/javascripts/discourse/controllers/user-activity-reactions.js.es6
@@ -21,7 +21,10 @@ export default Controller.extend({
       ? reactionUsers[reactionUsers.length - 1].get("id")
       : null;
 
-    const opts = { beforeReactionUserId };
+    const opts = {
+      beforeReactionUserId,
+      actingUsername: this.actingUsername,
+    };
 
     CustomReaction.findReactions(this.reactionsUrl, this.username, opts)
       .then((newReactionUsers) => {

--- a/assets/javascripts/discourse/models/discourse-reactions-custom-reaction.js.es6
+++ b/assets/javascripts/discourse/models/discourse-reactions-custom-reaction.js.es6
@@ -30,6 +30,10 @@ CustomReaction.reopenClass({
       data.before_reaction_user_id = opts.beforeReactionUserId;
     }
 
+    if (opts.actingUsername) {
+      data.acting_username = opts.actingUsername;
+    }
+
     return ajax(`/discourse-reactions/posts/${url}.json`, {
       data,
     }).then((reactions) => {

--- a/assets/javascripts/discourse/routes/user-notifications-reactions-received.js.es6
+++ b/assets/javascripts/discourse/routes/user-notifications-reactions-received.js.es6
@@ -2,10 +2,15 @@ import DiscourseRoute from "discourse/routes/discourse";
 import CustomReaction from "../models/discourse-reactions-custom-reaction";
 
 export default DiscourseRoute.extend({
-  model() {
+  queryParams: {
+    acting_username: { refreshModel: true },
+  },
+
+  model(params) {
     return CustomReaction.findReactions(
       "reactions-received",
-      this.modelFor("user").get("username")
+      this.modelFor("user").get("username"),
+      { actingUsername: params.acting_username }
     );
   },
 
@@ -16,6 +21,7 @@ export default DiscourseRoute.extend({
       canLoadMore: !loadedAll,
       reactionsUrl: "reactions-received",
       username: this.modelFor("user").get("username"),
+      actingUsername: controller.acting_username,
     });
     this.controllerFor("application").set("showFooter", loadedAll);
   },

--- a/assets/javascripts/discourse/widgets/discourse-reactions-reaction-notification-item.js.es6
+++ b/assets/javascripts/discourse/widgets/discourse-reactions-reaction-notification-item.js.es6
@@ -68,8 +68,9 @@ createWidgetFrom(DefaultNotificationItem, "reaction-notification-item", {
     if (topicId) {
       return postUrl(this.attrs.slug, topicId, this.attrs.post_number);
     } else {
+      const data = this.attrs.data;
       return userPath(
-        `${this.currentUser.username}/notifications/reactions-received`
+        `${this.currentUser.username}/notifications/reactions-received?acting_username=${data.display_username}`
       );
     }
   },

--- a/spec/requests/custom_reactions_controller_spec.rb
+++ b/spec/requests/custom_reactions_controller_spec.rb
@@ -208,6 +208,21 @@ describe DiscourseReactions::CustomReactionsController do
       expect(parsed[0]['post']['user']['id']).to eq(user_1.id)
       expect(parsed[0]['reaction']['id']).to eq(reaction_2.id)
     end
+
+    it 'filters by acting username' do
+      sign_in(user_1)
+
+      get "/discourse-reactions/posts/reactions-received.json", params: {
+        username: user_1.username, acting_username: user_4.username
+      }
+      parsed = response.parsed_body
+
+      expect(parsed.size).to eq(1)
+      expect(parsed[0]['user']['id']).to eq(user_4.id)
+      expect(parsed[0]['post_id']).to eq(post_2.id)
+      expect(parsed[0]['post']['user']['id']).to eq(user_1.id)
+      expect(parsed[0]['reaction']['id']).to eq(reaction_3.id)
+    end
   end
 
   context '#post_reactions_users' do


### PR DESCRIPTION
Adds an `acting_username` filter to the reactions-received endpoints.