### PR TITLE
FIX: Include likes in the reactions received list.

### DIFF
--- a/app/controllers/discourse_reactions/custom_reactions_controller.rb
+++ b/app/controllers/discourse_reactions/custom_reactions_controller.rb
@@ -96,14 +96,17 @@ module DiscourseReactions
       likes = post.post_actions.where('deleted_at IS NULL AND post_action_type_id = ?', PostActionType.types[:like]) if !reaction_value || reaction_value == DiscourseReactions::Reaction.main_reaction_id
 
       if likes.present?
-        main_reaction = DiscourseReactions::Reaction.find_by(reaction_value: DiscourseReactions::Reaction.main_reaction_id, post_id: post.id)
         count = likes.length
         users = format_likes_users(likes)
 
-        if main_reaction && main_reaction[:reaction_users_count]
-          (users << get_users(main_reaction)).flatten!
-          users.sort_by! { |user| user[:created_at] }
-          count += main_reaction.reaction_users_count.to_i
+        if DiscourseReactions::Reaction.main_reaction_id != DiscourseReactions::ReactionManager::DEFAULT_REACTION_VALUE
+          main_reaction = DiscourseReactions::Reaction.find_by(reaction_value: DiscourseReactions::Reaction.main_reaction_id, post_id: post.id)
+
+          if main_reaction && main_reaction[:reaction_users_count]
+            (users << get_users(main_reaction)).flatten!
+            users.sort_by! { |user| user[:created_at] }
+            count += main_reaction.reaction_users_count.to_i
+          end
         end
 
         reaction_users << {

--- a/app/services/discourse_reactions/reaction_manager.rb
+++ b/app/services/discourse_reactions/reaction_manager.rb
@@ -2,6 +2,8 @@
 
 module DiscourseReactions
   class ReactionManager
+    DEFAULT_REACTION_VALUE = 'heart'
+
     def initialize(reaction_value:, user:, guardian:, post:)
       @reaction_value = reaction_value
       @user = user
@@ -25,7 +27,7 @@ module DiscourseReactions
     private
 
     def toggle_like
-      remove_reaction if reaction_user
+      reaction_user ? remove_reaction : add_reaction
       @like ? remove_shadow_like : add_shadow_like
     end
 
@@ -77,17 +79,10 @@ module DiscourseReactions
     def add_shadow_like
       silent = true
       PostActionCreator.like(@user, @post, silent)
-      add_reaction_notification
     end
 
     def remove_shadow_like
       PostActionDestroyer.new(@user, @post, post_action_like_type).perform
-      delete_like_reaction
-      remove_reaction_notification
-    end
-
-    def delete_like_reaction
-      DiscourseReactions::Reaction.where("reaction_value = '#{DiscourseReactions::Reaction.main_reaction_id}' AND post_id = ?", @post.id).destroy_all
     end
 
     def add_reaction
@@ -97,7 +92,7 @@ module DiscourseReactions
     end
 
     def remove_reaction
-      @reaction_user.destroy
+      @reaction_user&.destroy
       remove_reaction_notification
       delete_reaction
     end

--- a/app/services/discourse_reactions/reaction_notification.rb
+++ b/app/services/discourse_reactions/reaction_notification.rb
@@ -2,8 +2,6 @@
 
 module DiscourseReactions
   class ReactionNotification
-    HEART_ICON_NAME = 'heart'
-
     def initialize(reaction, user)
       @reaction = reaction
       @post = reaction.post
@@ -17,7 +15,7 @@ module DiscourseReactions
 
       opts = { user_id: @user.id, display_username: @user.username }
 
-      if @reaction.reaction_value == HEART_ICON_NAME
+      if @reaction.reaction_value == DiscourseReactions::ReactionManager::DEFAULT_REACTION_VALUE
         opts[:custom_data] = { reaction_icon: @reaction.reaction_value }
       end
 
@@ -66,8 +64,8 @@ module DiscourseReactions
         data[:username2] = remaining_data[1][0]
       end
 
-      if remaining_data.all? { |element| element[1] == HEART_ICON_NAME }
-        data[:reaction_icon] = HEART_ICON_NAME
+      if remaining_data.all? { |element| element[1] == DiscourseReactions::ReactionManager::DEFAULT_REACTION_VALUE }
+        data[:reaction_icon] = DiscourseReactions::ReactionManager::DEFAULT_REACTION_VALUE
       end
 
       Notification.create(

--- a/assets/javascripts/discourse/widgets/discourse-reactions-reaction-notification-item.js.es6
+++ b/assets/javascripts/discourse/widgets/discourse-reactions-reaction-notification-item.js.es6
@@ -69,8 +69,15 @@ createWidgetFrom(DefaultNotificationItem, "reaction-notification-item", {
       return postUrl(this.attrs.slug, topicId, this.attrs.post_number);
     } else {
       const data = this.attrs.data;
+      let activityName = "reactions-received";
+
+      // All collapsed notifications were "likes"
+      if (data.reaction_icon) {
+        activityName = "likes-received";
+      }
+
       return userPath(
-        `${this.currentUser.username}/notifications/reactions-received?acting_username=${data.display_username}`
+        `${this.currentUser.username}/notifications/${activityName}?acting_username=${data.display_username}`
       );
     }
   },

--- a/plugin.rb
+++ b/plugin.rb
@@ -297,13 +297,11 @@ after_initialize do
         if existing_notification_of_same_type
           same_type_data = existing_notification_of_same_type.data_hash
 
-          new_data = data.merge(
+          data.merge(
             previous_notification_id: existing_notification_of_same_type.id,
             username2: same_type_data[:display_username],
             count: (same_type_data[:count] || 1).to_i + 1
           )
-
-          new_data
         else
           data
         end


### PR DESCRIPTION
We no longer use like notifications to reduce the overlap between them and reactions. Instead, we replaced them with reaction notifications that display the heart icon, looking the same. Since we replaced them, clicking a consolidated reaction notification will point users to the reactions received page, which doesn't list likes, so the user won't seif one of the consolidated was a "like" the user won't see it.

To fix this, we'll create a reaction user object alongside the post-action when toggling a like, including it in the list. Additionally, if all the consolidated reactions were likes, the notification links to the likes received list instead.