### PR TITLE
Revert "FIX: Include likes in the reactions received list."

### DIFF
--- a/app/controllers/discourse_reactions/custom_reactions_controller.rb
+++ b/app/controllers/discourse_reactions/custom_reactions_controller.rb
@@ -96,17 +96,14 @@ module DiscourseReactions
       likes = post.post_actions.where('deleted_at IS NULL AND post_action_type_id = ?', PostActionType.types[:like]) if !reaction_value || reaction_value == DiscourseReactions::Reaction.main_reaction_id
 
       if likes.present?
+        main_reaction = DiscourseReactions::Reaction.find_by(reaction_value: DiscourseReactions::Reaction.main_reaction_id, post_id: post.id)
         count = likes.length
         users = format_likes_users(likes)
 
-        if DiscourseReactions::Reaction.main_reaction_id != DiscourseReactions::ReactionManager::DEFAULT_REACTION_VALUE
-          main_reaction = DiscourseReactions::Reaction.find_by(reaction_value: DiscourseReactions::Reaction.main_reaction_id, post_id: post.id)
-
-          if main_reaction && main_reaction[:reaction_users_count]
-            (users << get_users(main_reaction)).flatten!
-            users.sort_by! { |user| user[:created_at] }
-            count += main_reaction.reaction_users_count.to_i
-          end
+        if main_reaction && main_reaction[:reaction_users_count]
+          (users << get_users(main_reaction)).flatten!
+          users.sort_by! { |user| user[:created_at] }
+          count += main_reaction.reaction_users_count.to_i
         end
 
         reaction_users << {

--- a/app/services/discourse_reactions/reaction_notification.rb
+++ b/app/services/discourse_reactions/reaction_notification.rb
@@ -2,6 +2,8 @@
 
 module DiscourseReactions
   class ReactionNotification
+    HEART_ICON_NAME = 'heart'
+
     def initialize(reaction, user)
       @reaction = reaction
       @post = reaction.post
@@ -15,7 +17,7 @@ module DiscourseReactions
 
       opts = { user_id: @user.id, display_username: @user.username }
 
-      if @reaction.reaction_value == DiscourseReactions::ReactionManager::DEFAULT_REACTION_VALUE
+      if @reaction.reaction_value == HEART_ICON_NAME
         opts[:custom_data] = { reaction_icon: @reaction.reaction_value }
       end
 
@@ -64,8 +66,8 @@ module DiscourseReactions
         data[:username2] = remaining_data[1][0]
       end
 
-      if remaining_data.all? { |element| element[1] == DiscourseReactions::ReactionManager::DEFAULT_REACTION_VALUE }
-        data[:reaction_icon] = DiscourseReactions::ReactionManager::DEFAULT_REACTION_VALUE
+      if remaining_data.all? { |element| element[1] == HEART_ICON_NAME }
+        data[:reaction_icon] = HEART_ICON_NAME
       end
 
       Notification.create(

--- a/assets/javascripts/discourse/widgets/discourse-reactions-reaction-notification-item.js.es6
+++ b/assets/javascripts/discourse/widgets/discourse-reactions-reaction-notification-item.js.es6
@@ -69,15 +69,8 @@ createWidgetFrom(DefaultNotificationItem, "reaction-notification-item", {
       return postUrl(this.attrs.slug, topicId, this.attrs.post_number);
     } else {
       const data = this.attrs.data;
-      let activityName = "reactions-received";
-
-      // All collapsed notifications were "likes"
-      if (data.reaction_icon) {
-        activityName = "likes-received";
-      }
-
       return userPath(
-        `${this.currentUser.username}/notifications/${activityName}?acting_username=${data.display_username}`
+        `${this.currentUser.username}/notifications/reactions-received?acting_username=${data.display_username}`
       );
     }
   },

--- a/plugin.rb
+++ b/plugin.rb
@@ -297,11 +297,13 @@ after_initialize do
         if existing_notification_of_same_type
           same_type_data = existing_notification_of_same_type.data_hash
 
-          data.merge(
+          new_data = data.merge(
             previous_notification_id: existing_notification_of_same_type.id,
             username2: same_type_data[:display_username],
             count: (same_type_data[:count] || 1).to_i + 1
           )
+
+          new_data
         else
           data
         end

--- a/spec/requests/custom_reactions_controller_spec.rb
+++ b/spec/requests/custom_reactions_controller_spec.rb
@@ -11,7 +11,6 @@ describe DiscourseReactions::CustomReactionsController do
   fab!(:user_3) { Fabricate(:user) }
   fab!(:user_4) { Fabricate(:user) }
   fab!(:user_5) { Fabricate(:user) }
-  fab!(:user_6) { Fabricate(:user) }
   fab!(:post_2) { Fabricate(:post, user: user_1) }
   fab!(:reaction_1) { Fabricate(:reaction, post: post_2, reaction_value: "laughing") }
   fab!(:reaction_2) { Fabricate(:reaction, post: post_2, reaction_value: "open_mouth") }
@@ -224,27 +223,6 @@ describe DiscourseReactions::CustomReactionsController do
       expect(parsed[0]['post']['user']['id']).to eq(user_1.id)
       expect(parsed[0]['reaction']['id']).to eq(reaction_3.id)
     end
-
-    it 'include likes' do
-      sign_in(user_6)
-
-      put "/discourse-reactions/posts/#{post_2.id}/custom-reactions/heart/toggle.json"
-
-      sign_in(user_1)
-
-      get "/discourse-reactions/posts/reactions-received.json", params: {
-        username: user_1.username, acting_username: user_6.username
-      }
-      parsed = response.parsed_body
-
-      expect(parsed.size).to eq(1)
-      expect(parsed[0]['user']['id']).to eq(user_6.id)
-      expect(parsed[0]['post_id']).to eq(post_2.id)
-      expect(parsed[0]['post']['user']['id']).to eq(user_1.id)
-
-      used_reaction = DiscourseReactions::Reaction.find_by(id: parsed[0]['reaction']['id'])
-      expect(used_reaction.reaction_value).to eq(SiteSetting.discourse_reactions_like_icon)
-    end
   end
 
   context '#post_reactions_users' do
@@ -280,30 +258,18 @@ describe DiscourseReactions::CustomReactionsController do
       get "/discourse-reactions/posts/#{post_2.id}/reactions-users.json?reaction_value=#{DiscourseReactions::Reaction.main_reaction_id}"
       parsed = response.parsed_body
       like_count = parsed["reaction_users"][0]["count"].to_i
-      expect(like_count).to eq(post_2.like_count)
+      expect(parsed["reaction_users"][0]["count"]).to eq(post_2.like_count)
 
       get "/discourse-reactions/posts/#{post_2.id}/reactions-users.json?reaction_value=laughing"
       parsed = response.parsed_body
       reaction_count = parsed["reaction_users"][0]["count"].to_i
-      expect(reaction_count).to eq(reaction_1.reaction_users_count)
+      expect(parsed["reaction_users"][0]["count"]).to eq(reaction_1.reaction_users_count)
 
       SiteSetting.discourse_reactions_reaction_for_like = 'laughing'
 
       get "/discourse-reactions/posts/#{post_2.id}/reactions-users.json?reaction_value=#{DiscourseReactions::Reaction.main_reaction_id}"
       parsed = response.parsed_body
       expect(parsed["reaction_users"][0]["count"]).to eq(like_count + reaction_count)
-    end
-
-    it "don't duplicate likes when using the default like icon" do
-      sign_in(user_6)
-
-      put "/discourse-reactions/posts/#{post_1.id}/custom-reactions/heart/toggle.json"
-
-      get "/discourse-reactions/posts/#{post_1.id}/reactions-users.json"
-      parsed = response.parsed_body
-      like_count = parsed["reaction_users"][0]["count"].to_i
-
-      expect(like_count).to eq(1)
     end
   end
 


### PR DESCRIPTION
There are some places where we assume that a "heart" reaction user doesn't exist. Reverting for now.

Reverts discourse/discourse-reactions#131
