### PR TITLE
FIX: Show likes for consolidated/collapsed consolidation notifications.

### DIFF
--- a/assets/javascripts/discourse/controllers/user-activity-reactions.js.es6
+++ b/assets/javascripts/discourse/controllers/user-activity-reactions.js.es6
@@ -7,6 +7,36 @@ export default Controller.extend({
   canLoadMore: true,
   loading: false,
   application: controller(),
+  beforeLikeId: null,
+  beforeReactionUserId: null,
+
+  _getLastIdFrom(array) {
+    return array.length ? array[array.length - 1].get("id") : null;
+  },
+
+  _updateBeforeIds(reactionUsers) {
+    if (this.includeLikes) {
+      const mainReaction = this.siteSettings
+        .discourse_reactions_reaction_for_like;
+      const [likes, reactions] = reactionUsers.reduce(
+        (memo, elem) => {
+          if (elem.reaction.reaction_value === mainReaction) {
+            memo[0].push(elem);
+          } else {
+            memo[1].push(elem);
+          }
+
+          return memo;
+        },
+        [[], []]
+      );
+
+      this.beforeLikeId = this._getLastIdFrom(likes);
+      this.beforeReactionUserId = this._getLastIdFrom(reactions);
+    } else {
+      this.beforeReactionUserId = this._getLastIdFrom(reactionUsers);
+    }
+  },
 
   @action
   loadMore() {
@@ -17,18 +47,21 @@ export default Controller.extend({
     this.set("loading", true);
     const reactionUsers = this.model;
 
-    const beforeReactionUserId = reactionUsers.length
-      ? reactionUsers[reactionUsers.length - 1].get("id")
-      : null;
+    if (!this.beforeReactionUserId) {
+      this._updateBeforeIds(reactionUsers);
+    }
 
     const opts = {
-      beforeReactionUserId,
       actingUsername: this.actingUsername,
+      includeLikes: this.includeLikes,
+      beforeLikeId: this.beforeLikeId,
+      beforeReactionUserId: this.beforeReactionUserId,
     };
 
     CustomReaction.findReactions(this.reactionsUrl, this.username, opts)
       .then((newReactionUsers) => {
         reactionUsers.addObjects(newReactionUsers);
+        this._updateBeforeIds(newReactionUsers);
         if (newReactionUsers.length === 0) {
           this.set("canLoadMore", false);
         }

--- a/assets/javascripts/discourse/models/discourse-reactions-custom-reaction.js.es6
+++ b/assets/javascripts/discourse/models/discourse-reactions-custom-reaction.js.es6
@@ -30,6 +30,14 @@ CustomReaction.reopenClass({
       data.before_reaction_user_id = opts.beforeReactionUserId;
     }
 
+    if (opts.beforeLikeId) {
+      data.before_like_id = opts.beforeLikeId;
+    }
+
+    if (opts.includeLikes) {
+      data.include_likes = opts.includeLikes;
+    }
+
     if (opts.actingUsername) {
       data.acting_username = opts.actingUsername;
     }

--- a/assets/javascripts/discourse/routes/user-notifications-reactions-received.js.es6
+++ b/assets/javascripts/discourse/routes/user-notifications-reactions-received.js.es6
@@ -4,13 +4,17 @@ import CustomReaction from "../models/discourse-reactions-custom-reaction";
 export default DiscourseRoute.extend({
   queryParams: {
     acting_username: { refreshModel: true },
+    include_likes: { refreshModel: true },
   },
 
   model(params) {
     return CustomReaction.findReactions(
       "reactions-received",
       this.modelFor("user").get("username"),
-      { actingUsername: params.acting_username }
+      {
+        actingUsername: params.acting_username,
+        includeLikes: params.include_likes,
+      }
     );
   },
 
@@ -22,6 +26,7 @@ export default DiscourseRoute.extend({
       reactionsUrl: "reactions-received",
       username: this.modelFor("user").get("username"),
       actingUsername: controller.acting_username,
+      includeLikes: controller.include_likes,
     });
     this.controllerFor("application").set("showFooter", loadedAll);
   },

--- a/assets/javascripts/discourse/widgets/discourse-reactions-reaction-notification-item.js.es6
+++ b/assets/javascripts/discourse/widgets/discourse-reactions-reaction-notification-item.js.es6
@@ -69,8 +69,15 @@ createWidgetFrom(DefaultNotificationItem, "reaction-notification-item", {
       return postUrl(this.attrs.slug, topicId, this.attrs.post_number);
     } else {
       const data = this.attrs.data;
+      let activityName = "reactions-received";
+
+      // All collapsed notifications were "likes"
+      if (data.reaction_icon) {
+        activityName = "likes-received";
+      }
+
       return userPath(
-        `${this.currentUser.username}/notifications/reactions-received?acting_username=${data.display_username}`
+        `${this.currentUser.username}/notifications/${activityName}?acting_username=${data.display_username}&include_likes=true`
       );
     }
   },

--- a/spec/requests/custom_reactions_controller_spec.rb
+++ b/spec/requests/custom_reactions_controller_spec.rb
@@ -223,6 +223,57 @@ describe DiscourseReactions::CustomReactionsController do
       expect(parsed[0]['post']['user']['id']).to eq(user_1.id)
       expect(parsed[0]['reaction']['id']).to eq(reaction_3.id)
     end
+
+    it 'include likes' do
+      sign_in(user_1)
+
+      get "/discourse-reactions/posts/reactions-received.json", params: {
+        username: user_1.username, include_likes: true, acting_username: user_5.username
+      }
+
+      parsed = response.parsed_body
+
+      expect(parsed.size).to eq(1)
+      expect(parsed[0]['user']['id']).to eq(user_5.id)
+      expect(parsed[0]['post_id']).to eq(post_2.id)
+      expect(parsed[0]['post']['user']['id']).to eq(user_1.id)
+      expect(parsed[0]['reaction']['id']).to eq(like.id)
+    end
+
+    it 'also filter likes by id when including likes' do
+      latest_like = Fabricate(:post_action, post: post_1, user: user_5, post_action_type_id: PostActionType.types[:like])
+      sign_in(user_1)
+
+      get "/discourse-reactions/posts/reactions-received.json", params: {
+        username: user_1.username, include_likes: true, acting_username: user_5.username,
+        before_like_id: latest_like.id
+      }
+
+      parsed = response.parsed_body
+
+      expect(parsed.size).to eq(1)
+      expect(parsed[0]['user']['id']).to eq(user_5.id)
+      expect(parsed[0]['post_id']).to eq(post_2.id)
+      expect(parsed[0]['post']['user']['id']).to eq(user_1.id)
+      expect(parsed[0]['reaction']['id']).to eq(like.id)
+    end
+
+    it 'filters likes by username' do
+      latest_like = Fabricate(:post_action, post: post_1, user: user_4, post_action_type_id: PostActionType.types[:like])
+      sign_in(user_1)
+
+      get "/discourse-reactions/posts/reactions-received.json", params: {
+        username: user_1.username, include_likes: true, acting_username: user_5.username
+      }
+
+      parsed = response.parsed_body
+
+      expect(parsed.size).to eq(1)
+      expect(parsed[0]['user']['id']).to eq(user_5.id)
+      expect(parsed[0]['post_id']).to eq(post_2.id)
+      expect(parsed[0]['post']['user']['id']).to eq(user_1.id)
+      expect(parsed[0]['reaction']['id']).to eq(like.id)
+    end
   end
 
   context '#post_reactions_users' do


### PR DESCRIPTION
It fixes the same issue as 5c5ab85, but it's safer. The idea is to include likes by getting the post actions associated with the user posts and "cast" them into reactions. Since we deal with two different tables, we need to keep track of two "before ID" filters.