### PR TITLE
FIX: Rename thumbsup emoji to +1

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -12,7 +12,7 @@ discourse_reactions:
     enum: ReactionForLikeSiteSettingEnum
   discourse_reactions_enabled_reactions:
     type: emoji_list
-    default: thumbsup|laughing|open_mouth|clap|confetti_ball|hugs
+    default: +1|laughing|open_mouth|clap|confetti_ball|hugs
     client: true
   discourse_reactions_desaturated_reaction_panel:
     default: false

--- a/db/post_migrate/20220201162748_rename_thumbsup_reactions.rb
+++ b/db/post_migrate/20220201162748_rename_thumbsup_reactions.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+class RenameThumbsupReactions < ActiveRecord::Migration[6.1]
+  def up
+    current_reactions = DB.query_single(
+      "SELECT value FROM site_settings WHERE name = 'discourse_reactions_enabled_reactions'"
+    )[0]
+
+    alias_name = 'thumbsup'
+    original_name = '+1'
+
+    if current_reactions
+      updated_reactions = current_reactions.gsub(alias_name, original_name)
+
+      DB.exec(<<~SQL, updated_reactions: updated_reactions)
+        UPDATE site_settings
+        SET value = :updated_reactions
+        WHERE name = 'discourse_reactions_enabled_reactions'
+      SQL
+    end
+
+    DB.exec(<<~SQL, alias: alias_name, new_value: original_name)
+      UPDATE discourse_reactions_reactions
+      SET reaction_value = :new_value
+      WHERE reaction_value = :alias
+    SQL
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end


### PR DESCRIPTION
Reacting to a post with thumbs up doesn't work because it's an alias. This PR updates the default value to +1, the original emoji name, and updates existing reactions.