### PR TITLE
FIX: Remove thumbsup reactions when there's also a +1 reaction.

### DIFF
--- a/db/post_migrate/20220201162748_rename_thumbsup_reactions.rb
+++ b/db/post_migrate/20220201162748_rename_thumbsup_reactions.rb
@@ -19,10 +19,31 @@ class RenameThumbsupReactions < ActiveRecord::Migration[6.1]
       SQL
     end
 
-    DB.exec(<<~SQL, alias: alias_name, new_value: original_name)
+    has_both_reactions = DB.query_single(<<~SQL, alias: alias_name, new_value: original_name)
+      SELECT post_id 
+      FROM discourse_reactions_reactions 
+      WHERE reaction_value IN (:alias, :new_value) 
+      GROUP BY post_id 
+      HAVING COUNT(post_id) > 1
+    SQL
+
+    if has_both_reactions.present?
+      reaction_ids = DB.exec(<<~SQL, conflicts: has_both_reactions, alias: alias_name)
+        DELETE FROM discourse_reactions_reactions
+        WHERE post_id IN (:conflicts) AND reaction_value = :alias
+        RETURNING id
+      SQL
+
+      DB.exec(<<~SQL, deleted_reactions: reaction_ids)
+        DELETE FROM discourse_reactions_reaction_users
+        WHERE reaction_id IN (:deleted_reactions)
+      SQL
+    end
+
+    DB.exec(<<~SQL, alias: alias_name, new_value: original_name, conflicts: has_both_reactions)
       UPDATE discourse_reactions_reactions
       SET reaction_value = :new_value
-      WHERE reaction_value = :alias
+      WHERE reaction_value = :alias AND post_id NOT IN (:conflicts)
     SQL
   end
 


### PR DESCRIPTION
The thumbsup reaction didn't work, so we recommended using +1 instead as a workaround. The post will have both reactions associated if someone reacted with a thumbsup, then it was renamed to +1, and another user reacted with a +1.

The post-migration to rename thumbsup reactions we added in a previous commit won't work in the above scenario, so we should directly remove them and leave the existing +1 reactions.