### PR TITLE
A11Y: ensures focus on reaction button is clearly visible

### DIFF
--- a/assets/stylesheets/common/discourse-reactions.scss
+++ b/assets/stylesheets/common/discourse-reactions.scss
@@ -473,7 +473,7 @@ nav.post-controls .actions button {
 
 nav.post-controls .actions .reaction-button:focus {
   background: var(--primary-low);
-  color: var(--primary-low-mid);
+  color: var(--primary);
 }
 
 nav.post-controls .actions .reaction-button {

--- a/assets/stylesheets/common/discourse-reactions.scss
+++ b/assets/stylesheets/common/discourse-reactions.scss
@@ -472,7 +472,7 @@ nav.post-controls .actions button {
 }
 
 nav.post-controls .actions .reaction-button:focus {
-  background: transparent;
+  background: var(--primary-low);
   color: var(--primary-low-mid);
 }
 


### PR DESCRIPTION
<img width="251" alt="Screenshot 2022-02-28 at 10 28 16" src="https://user-images.githubusercontent.com/339945/155958672-95466dca-fc2a-42eb-b003-4107211118b6.png">

<img width="200" alt="Screenshot 2022-02-28 at 11 10 42" src="https://user-images.githubusercontent.com/339945/155964801-534bb472-0e20-42d4-9bb6-ddbdf45506d7.png">

