### PR TITLE
DEV: implements a toggled reaction appEvent

### DIFF
--- a/assets/javascripts/discourse/models/discourse-reactions-custom-reaction.js
+++ b/assets/javascripts/discourse/models/discourse-reactions-custom-reaction.js
@@ -15,11 +15,16 @@ const CustomReaction = RestModel.extend({
 });
 
 CustomReaction.reopenClass({
-  toggle(postId, reactionId) {
+  toggle(post, reactionId) {
     return ajax(
-      `/discourse-reactions/posts/${postId}/custom-reactions/${reactionId}/toggle.json`,
+      `/discourse-reactions/posts/${post.id}/custom-reactions/${reactionId}/toggle.json`,
       { type: "PUT" }
-    );
+    ).then((result) => {
+      post.appEvents.trigger("discourse-reactions:reaction-toggled", {
+        post: result,
+        reaction: result.current_user_reaction,
+      });
+    });
   },
 
   findReactions(url, username, opts) {

--- a/assets/javascripts/discourse/widgets/discourse-reactions-actions.js
+++ b/assets/javascripts/discourse/widgets/discourse-reactions-actions.js
@@ -271,7 +271,7 @@ export default createWidget("discourse-reactions-actions", {
 
               later(() => {
                 dropReaction(postContainer, params.reaction, () => {
-                  return CustomReaction.toggle(params.postId, params.reaction)
+                  return CustomReaction.toggle(this.attrs.post, params.reaction)
                     .then(resolve)
                     .catch((e) => {
                       bootbox.alert(this._extractErrors(e));
@@ -283,7 +283,7 @@ export default createWidget("discourse-reactions-actions", {
               addReaction(postContainer, params.reaction, () => {
                 this.toggleReaction(params);
 
-                CustomReaction.toggle(params.postId, params.reaction)
+                CustomReaction.toggle(this.attrs.post, params.reaction)
                   .then(resolve)
                   .catch((e) => {
                     bootbox.alert(this._extractErrors(e));
@@ -442,7 +442,7 @@ export default createWidget("discourse-reactions-actions", {
 
     if (current_user_reaction && current_user_reaction.id === attrs.reaction) {
       this.toggleReaction(attrs);
-      return CustomReaction.toggle(this.attrs.post.id, attrs.reaction).catch(
+      return CustomReaction.toggle(this.attrs.post, attrs.reaction).catch(
         (e) => {
           bootbox.alert(this._extractErrors(e));
           this._rollbackState(post);
@@ -478,7 +478,7 @@ export default createWidget("discourse-reactions-actions", {
               ? attrs.reaction
               : this.siteSettings.discourse_reactions_reaction_for_like;
 
-          CustomReaction.toggle(this.attrs.post.id, toggleReaction)
+          CustomReaction.toggle(this.attrs.post, toggleReaction)
             .then(resolve)
             .catch((e) => {
               bootbox.alert(this._extractErrors(e));


### PR DESCRIPTION
Usage:

```
api.onAppEvent("discourse-reactions:reaction-toggled", (post, reaction) => {
 // if a reaction is present it will return an object similar to this one
 // { id: 'confetti_ball', type: 'emoji', can_undo: true }
 // otherwise reaction will be null
});
```