### PR TITLE
FIX: Publish old and new reaction on toggle

### DIFF
--- a/app/services/discourse_reactions/reaction_manager.rb
+++ b/app/services/discourse_reactions/reaction_manager.rb
@@ -2,12 +2,19 @@
 
 module DiscourseReactions
   class ReactionManager
+    attr_reader :reaction_value, :previous_reaction_value
+
     def initialize(reaction_value:, user:, guardian:, post:)
       @reaction_value = reaction_value
       @user = user
       @guardian = guardian
       @post = post
       @like = @post.post_actions.find_by(user: @user, post_action_type_id: post_action_like_type)
+      @previous_reaction_value = if @like
+        DiscourseReactions::Reaction.main_reaction_id
+      elsif reaction_user
+        old_reaction_value(reaction_user)
+      end
     end
 
     def toggle!
@@ -31,7 +38,6 @@ module DiscourseReactions
 
     def toggle_reaction
       if reaction_user
-        previous_reaction_value = old_reaction_value(reaction_user)
         remove_reaction
         return if previous_reaction_value && previous_reaction_value == @reaction_value
       end

--- a/spec/requests/custom_reactions_controller_spec.rb
+++ b/spec/requests/custom_reactions_controller_spec.rb
@@ -99,6 +99,17 @@ describe DiscourseReactions::CustomReactionsController do
       end
       expect(messages.count).to eq(2)
       expect(messages.map(&:channel).uniq.first).to eq("/topic/#{post_1.topic.id}/reactions")
+      expect(messages[0].data[:reactions]).to contain_exactly("cry")
+      expect(messages[1].data[:reactions]).to contain_exactly("cry")
+
+      messages = MessageBus.track_publish("/topic/#{post_1.topic.id}/reactions") do
+        put "/discourse-reactions/posts/#{post_1.id}/custom-reactions/cry/toggle.json"
+        put "/discourse-reactions/posts/#{post_1.id}/custom-reactions/angry/toggle.json"
+      end
+      expect(messages.count).to eq(2)
+      expect(messages.map(&:channel).uniq.first).to eq("/topic/#{post_1.topic.id}/reactions")
+      expect(messages[0].data[:reactions]).to contain_exactly("cry")
+      expect(messages[1].data[:reactions]).to contain_exactly("cry", "angry")
     end
 
     it 'errors when reaction is invalid' do


### PR DESCRIPTION
The old message that was published usually contained just the new
reaction once or twice. The new message that is published contains both
the old and new reactions which means that the client can refresh users
lists as needed.