### PR TITLE
FIX: always uses actions as parent widget

### DIFF
--- a/assets/javascripts/discourse/widgets/discourse-reactions-actions.js
+++ b/assets/javascripts/discourse/widgets/discourse-reactions-actions.js
@@ -159,7 +159,7 @@ export default createWidget("discourse-reactions-actions", {
   },
 
   touchStart() {
-    this._touchTimeout && cancel(this._touchTimeout);
+    cancel(this._touchTimeout);
 
     if (this.capabilities.touch) {
       const root = document.getElementsByTagName("html")[0];
@@ -175,7 +175,7 @@ export default createWidget("discourse-reactions-actions", {
   },
 
   touchEnd(event) {
-    this._touchTimeout && cancel(this._touchTimeout);
+    cancel(this._touchTimeout);
 
     const root = document.getElementsByTagName("html")[0];
     root && root.classList.remove("discourse-reactions-no-select");

--- a/assets/javascripts/discourse/widgets/discourse-reactions-counter.js
+++ b/assets/javascripts/discourse/widgets/discourse-reactions-counter.js
@@ -1,8 +1,6 @@
-import { createPopper } from "@popperjs/core";
 import { h } from "virtual-dom";
 import { iconNode } from "discourse-common/lib/icon-library";
 import { createWidget } from "discourse/widgets/widget";
-import { cancel, later, schedule } from "@ember/runloop";
 import CustomReaction from "../models/discourse-reactions-custom-reaction";
 
 let _popperStatePanel;
@@ -148,7 +146,7 @@ export default createWidget("discourse-reactions-counter", {
     }
   },
 
-  toggleStatePanel(event) {
+  toggleStatePanel() {
     if (!this.attrs.statePanelExpanded) {
       this.callWidgetFunction("expandStatePanel");
     } else {
@@ -156,11 +154,11 @@ export default createWidget("discourse-reactions-counter", {
     }
   },
 
-  mouseOver(event) {
+  mouseOver() {
     this.callWidgetFunction("cancelCollapse");
   },
 
-  mouseOut(event) {
+  mouseOut() {
     this.callWidgetFunction("scheduleCollapse", "collapseStatePanel");
   },
 });

--- a/assets/javascripts/discourse/widgets/discourse-reactions-picker.js
+++ b/assets/javascripts/discourse/widgets/discourse-reactions-picker.js
@@ -8,9 +8,19 @@ export default createWidget("discourse-reactions-picker", {
 
   buildKey: (attrs) => `discourse-reactions-picker-${attrs.post.id}`,
 
+  buildClasses(attrs) {
+    const classes = [];
+
+    if (attrs.reactionsPickerExpanded) {
+      classes.push("is-expanded");
+    }
+
+    return classes;
+  },
+
   mouseOut() {
     if (!window.matchMedia("(hover: none)").matches) {
-      this.callWidgetFunction("scheduleCollapse");
+      this.callWidgetFunction("scheduleCollapse", "collapseReactionsPicker");
     }
   },
 

--- a/assets/javascripts/discourse/widgets/discourse-reactions-reaction-button.js
+++ b/assets/javascripts/discourse/widgets/discourse-reactions-reaction-button.js
@@ -11,15 +11,7 @@ let _laterHoverHandlers = {};
 export default createWidget("discourse-reactions-reaction-button", {
   tagName: "div.discourse-reactions-reaction-button",
 
-  buildId: (attrs) =>
-    `discourse-reactions-reaction-button-${attrs.post.id}-${
-      attrs.position || "right"
-    }`,
-
-  buildKey: (attrs) =>
-    `discourse-reactions-reaction-button-${attrs.post.id}-${
-      attrs.position || "right"
-    }`,
+  buildKey: (attrs) => `discourse-reactions-reaction-button-${attrs.post.id}`,
 
   click() {
     this.callWidgetFunction("cancelCollapse");

--- a/assets/javascripts/discourse/widgets/discourse-reactions-reaction-button.js
+++ b/assets/javascripts/discourse/widgets/discourse-reactions-reaction-button.js
@@ -4,9 +4,6 @@ import { iconNode } from "discourse-common/lib/icon-library";
 import { emojiUrlFor } from "discourse/lib/text";
 import { h } from "virtual-dom";
 import { createWidget } from "discourse/widgets/widget";
-import { cancel, later } from "@ember/runloop";
-
-let _laterHoverHandlers = {};
 
 export default createWidget("discourse-reactions-reaction-button", {
   tagName: "div.discourse-reactions-reaction-button",

--- a/assets/javascripts/discourse/widgets/discourse-reactions-reaction-button.js
+++ b/assets/javascripts/discourse/widgets/discourse-reactions-reaction-button.js
@@ -11,10 +11,19 @@ let _laterHoverHandlers = {};
 export default createWidget("discourse-reactions-reaction-button", {
   tagName: "div.discourse-reactions-reaction-button",
 
-  buildKey: (attrs) => `discourse-reactions-reaction-button-${attrs.post.id}`,
+  buildId: (attrs) =>
+    `discourse-reactions-reaction-button-${attrs.post.id}-${
+      attrs.position || "right"
+    }`,
+
+  buildKey: (attrs) =>
+    `discourse-reactions-reaction-button-${attrs.post.id}-${
+      attrs.position || "right"
+    }`,
 
   click() {
-    this._cancelHoverHandler();
+    this.callWidgetFunction("cancelCollapse");
+
     const currentUserReaction = this.attrs.post.current_user_reaction;
     if (!this.capabilities.touch || !this.site.mobileView) {
       this.callWidgetFunction("toggleFromButton", {
@@ -26,7 +35,7 @@ export default createWidget("discourse-reactions-reaction-button", {
   },
 
   mouseOver(event) {
-    this._cancelHoverHandler();
+    this.callWidgetFunction("cancelCollapse");
 
     const likeAction = this.attrs.post.likeAction;
     const currentUserReaction = this.attrs.post.current_user_reaction;
@@ -39,20 +48,13 @@ export default createWidget("discourse-reactions-reaction-button", {
     }
 
     if (!window.matchMedia("(hover: none)").matches) {
-      _laterHoverHandlers[this.attrs.post.id] = later(
-        this,
-        this._hoverHandler,
-        event,
-        500
-      );
+      this.callWidgetFunction("toggleReactions", event);
     }
   },
 
   mouseOut() {
-    this._cancelHoverHandler();
-
     if (!window.matchMedia("(hover: none)").matches) {
-      this.callWidgetFunction("scheduleCollapse");
+      this.callWidgetFunction("scheduleCollapse", "collapseReactionsPicker");
     }
   },
 
@@ -135,16 +137,5 @@ export default createWidget("discourse-reactions-reaction-button", {
       },
       [iconNode(`far-${mainReactionIcon}`)]
     );
-  },
-
-  _cancelHoverHandler() {
-    const handler = _laterHoverHandlers[this.attrs.post.id];
-    handler && cancel(handler);
-  },
-
-  _hoverHandler(event) {
-    this.callWidgetFunction("cancelCollapse");
-    this.callWidgetFunction("toggleReactions", event);
-    this.callWidgetFunction("collapseStatePanel");
   },
 });

--- a/assets/javascripts/discourse/widgets/discourse-reactions-state-panel.js
+++ b/assets/javascripts/discourse/widgets/discourse-reactions-state-panel.js
@@ -15,12 +15,16 @@ export default createWidget("discourse-reactions-state-panel", {
       classes.push(`max-length-${charsCount}`);
     }
 
+    if (attrs.statePanelExpanded) {
+      classes.push("is-expanded");
+    }
+
     return classes;
   },
 
   mouseOut() {
     if (!window.matchMedia("(hover: none)").matches) {
-      this.callWidgetFunction("scheduleCollapse");
+      this.callWidgetFunction("scheduleCollapse", "collapseStatePanel");
     }
   },
 
@@ -67,7 +71,7 @@ export default createWidget("discourse-reactions-state-panel", {
             })
           )
         )
-      : h("div.spinner-container", h("div.spinner"));
+      : h("div.spinner-container", h("div.spinner.small"));
 
     return h("div.container", reactions);
   },

--- a/assets/javascripts/initializers/discourse-reactions.js
+++ b/assets/javascripts/initializers/discourse-reactions.js
@@ -78,8 +78,9 @@ function initializeDiscourseReactions(api) {
       return;
     }
 
-    return dec.attach("discourse-reactions-counter", {
+    return dec.attach("discourse-reactions-actions", {
       post,
+      position: "left",
     });
   });
 

--- a/assets/stylesheets/common/discourse-reactions.scss
+++ b/assets/stylesheets/common/discourse-reactions.scss
@@ -66,10 +66,6 @@ html.discourse-reactions-no-select {
         display: flex;
         flex-direction: column;
 
-        .spinner-container {
-          align-self: center;
-        }
-
         .heading {
           font-weight: 700;
           font-size: $font-up-1;
@@ -113,16 +109,12 @@ html.discourse-reactions-no-select {
 }
 
 .discourse-reactions-picker {
-  visibility: hidden;
-  display: none;
-  padding: 15px 0;
   z-index: z("usercard") - 2;
-  position: relative;
+  position: absolute;
+  visibility: hidden;
+  padding: 15px 0;
 
   &.is-expanded {
-    animation: 0.33s fadeIn;
-    animation-fill-mode: forwards;
-    display: flex;
     visibility: visible;
   }
 
@@ -178,13 +170,16 @@ html.discourse-reactions-no-select {
 }
 
 .discourse-reactions-state-panel {
-  min-width: 80px;
-  max-width: 275px;
-  visibility: hidden;
-  display: none;
-  padding: 15px 0;
   z-index: z("usercard") - 2;
-  position: relative;
+  position: absolute;
+  visibility: hidden;
+  padding: 15px 0;
+
+  &.is-expanded {
+    min-width: 80px;
+    max-width: 275px;
+    visibility: visible;
+  }
 
   .discourse-reactions-state-panel-reaction .count {
     padding-right: 0.25em;
@@ -196,13 +191,6 @@ html.discourse-reactions-no-select {
         width: #{$i * 10}px;
       }
     }
-  }
-
-  &.is-expanded {
-    animation: 0.33s fadeIn;
-    animation-fill-mode: forwards;
-    display: flex;
-    visibility: visible;
   }
 
   .container {
@@ -317,6 +305,13 @@ html.discourse-reactions-no-select {
 .discourse-reactions-actions {
   display: inline-flex;
   justify-content: flex-end;
+
+  .spinner-container {
+    align-self: center;
+    align-items: center;
+    justify-content: center;
+    display: flex;
+  }
 
   // manually account for emoji not being a perfect square
   .reactions-counter {


### PR DESCRIPTION
Doing this allows to vastly simplify all the expand/collapse events, this should fix multiple bugs related to these events.