### PR TITLE
UX: minor tweaks to expanding/collapsing panels

### DIFF
--- a/assets/javascripts/discourse/widgets/discourse-reactions-actions.js
+++ b/assets/javascripts/discourse/widgets/discourse-reactions-actions.js
@@ -497,7 +497,7 @@ export default createWidget("discourse-reactions-actions", {
   scheduleCollapse(handler) {
     this.cancelCollapse();
 
-    this._collapseHandler = later(this, this[handler], 1500);
+    this._collapseHandler = later(this, this[handler], 500);
   },
 
   buildId: (attrs) =>

--- a/assets/javascripts/discourse/widgets/discourse-reactions-counter.js
+++ b/assets/javascripts/discourse/widgets/discourse-reactions-counter.js
@@ -8,9 +8,11 @@ let _popperStatePanel;
 export default createWidget("discourse-reactions-counter", {
   tagName: "div",
 
-  buildKey: (attrs) => `discourse-reactions-counter-${attrs.post.id}`,
+  buildKey: (attrs) =>
+    `discourse-reactions-counter-${attrs.post.id}-${attrs.position || "right"}`,
 
-  buildId: (attrs) => `discourse-reactions-counter-${attrs.post.id}`,
+  buildId: (attrs) =>
+    `discourse-reactions-counter-${attrs.post.id}-${attrs.position || "right"}`,
 
   reactionsChanged(data) {
     data.reactions.uniq().forEach((reaction) => {
@@ -38,11 +40,22 @@ export default createWidget("discourse-reactions-counter", {
     });
   },
 
+  mouseDown(event) {
+    event.stopImmediatePropagation();
+    return false;
+  },
+
+  mouseUp(event) {
+    event.stopImmediatePropagation();
+    return false;
+  },
+
   click(event) {
     this.callWidgetFunction("cancelCollapse");
 
     if (!this.capabilities.touch || !this.site.mobileView) {
       event.stopPropagation();
+      event.preventDefault();
 
       if (!this.attrs.statePanelExpanded) {
         this.getUsers();
@@ -150,7 +163,7 @@ export default createWidget("discourse-reactions-counter", {
     if (!this.attrs.statePanelExpanded) {
       this.callWidgetFunction("expandStatePanel");
     } else {
-      this.callWidgetFunction("scheduleCollapse", "collapseStatePanel");
+      this.callWidgetFunction("collapseStatePanel");
     }
   },
 
@@ -158,7 +171,9 @@ export default createWidget("discourse-reactions-counter", {
     this.callWidgetFunction("cancelCollapse");
   },
 
-  mouseOut() {
-    this.callWidgetFunction("scheduleCollapse", "collapseStatePanel");
+  mouseOut(event) {
+    if (!event.relatedTarget?.closest(`#${this.buildId(this.attrs)}`)) {
+      this.callWidgetFunction("scheduleCollapse", "collapseStatePanel");
+    }
   },
 });

--- a/assets/javascripts/discourse/widgets/discourse-reactions-state-panel-reaction.js
+++ b/assets/javascripts/discourse/widgets/discourse-reactions-state-panel-reaction.js
@@ -30,6 +30,10 @@ export default createWidget("discourse-reactions-state-panel-reaction", {
   html(attrs) {
     const elements = [];
 
+    if (!attrs.users) {
+      return;
+    }
+
     elements.push(
       h("div.reaction-wrapper", [
         h("div.emoji-wrapper", [

--- a/assets/stylesheets/common/discourse-reactions.scss
+++ b/assets/stylesheets/common/discourse-reactions.scss
@@ -177,7 +177,6 @@ html.discourse-reactions-no-select {
 
   &.is-expanded {
     min-width: 80px;
-    max-width: 275px;
     visibility: visible;
   }
 


### PR DESCRIPTION
- no need for max width on state panel
- moves back later handler to 500ms
- instantly close state panel on click
- ensure we have users before attempting to compute state panel
- ensures quote-button is not causing panels to collapse
- ensures we actually mouseOut from counter and are not just hovering a different child