### PR TITLE
FIX: various minor fixes

### DIFF
--- a/assets/javascripts/discourse/widgets/discourse-reactions-actions.js
+++ b/assets/javascripts/discourse/widgets/discourse-reactions-actions.js
@@ -553,6 +553,10 @@ export default createWidget("discourse-reactions-actions", {
     this.scheduleRerender();
   },
 
+  updatePopperPosition() {
+    _popperPicker?.update();
+  },
+
   html(attrs) {
     const post = attrs.post;
     const items = [];

--- a/assets/javascripts/discourse/widgets/discourse-reactions-counter.js
+++ b/assets/javascripts/discourse/widgets/discourse-reactions-counter.js
@@ -37,6 +37,7 @@ export default createWidget("discourse-reactions-counter", {
 
       _popperStatePanel?.update();
       this.scheduleRerender();
+      this.callWidgetFunction("updatePopperPosition");
     });
   },
 
@@ -67,17 +68,29 @@ export default createWidget("discourse-reactions-counter", {
 
   clickOutside() {
     if (this.attrs.statePanelExpanded) {
-      this.callWidgetFunction("scheduleCollapse", "collapseStatePanel");
+      this.callWidgetFunction("collapseAllPanels");
     }
   },
 
   touchStart(event) {
+    this.callWidgetFunction("cancelCollapse");
+
+    if (
+      event.target.classList.contains("show-users") ||
+      event.target.classList.contains("avatar")
+    ) {
+      return true;
+    }
+
     if (this.attrs.statePanelExpanded) {
+      event.stopPropagation();
+      event.preventDefault();
       return;
     }
 
     if (this.capabilities.touch) {
       event.stopPropagation();
+      event.preventDefault();
       this.getUsers();
       this.toggleStatePanel(event);
     }

--- a/assets/stylesheets/common/discourse-reactions.scss
+++ b/assets/stylesheets/common/discourse-reactions.scss
@@ -263,6 +263,7 @@ html.discourse-reactions-no-select {
     align-items: center;
     justify-content: center;
     padding-top: 0.25em;
+    margin-left: 0 !important; // core rule has too much specificity
 
     .count {
       font-size: $font-down-1;
@@ -310,6 +311,7 @@ html.discourse-reactions-no-select {
     align-items: center;
     justify-content: center;
     display: flex;
+    margin-left: 0 !important; // core rule has too much specificity
   }
 
   // manually account for emoji not being a perfect square


### PR DESCRIPTION
- ensures popper position is updated after users are fetched
- override core css rule which is way too broad
- fixes another issue with quote-button receiving a selectionchange event it shouldn't
- ensures we cancel scheduled collapse when touchstart hits reaction counter
- ensures clickOutside is closing instantly and not scheduling