### PR TITLE
UX: slightly delay picker expand to prevent fast movements

### DIFF
--- a/assets/javascripts/discourse/widgets/discourse-reactions-actions.js
+++ b/assets/javascripts/discourse/widgets/discourse-reactions-actions.js
@@ -154,7 +154,11 @@ export default createWidget("discourse-reactions-actions", {
 
   toggleReactions(event) {
     if (!this.state.reactionsPickerExpanded) {
-      this.expandReactionsPicker(event);
+      if (this.state.statePanelExpanded) {
+        this.scheduleExpand("expandReactionsPicker");
+      } else {
+        this.expandReactionsPicker(event);
+      }
     }
   },
 
@@ -492,6 +496,16 @@ export default createWidget("discourse-reactions-actions", {
 
   cancelCollapse() {
     cancel(this._collapseHandler);
+  },
+
+  cancelExpand() {
+    cancel(this._expandHandler);
+  },
+
+  scheduleExpand(handler) {
+    this.cancelExpand();
+
+    this._expandHandler = later(this, this[handler], 250);
   },
 
   scheduleCollapse(handler) {

--- a/assets/javascripts/discourse/widgets/discourse-reactions-reaction-button.js
+++ b/assets/javascripts/discourse/widgets/discourse-reactions-reaction-button.js
@@ -42,6 +42,8 @@ export default createWidget("discourse-reactions-reaction-button", {
   },
 
   mouseOut() {
+    this.callWidgetFunction("cancelExpand");
+
     if (!window.matchMedia("(hover: none)").matches) {
       this.callWidgetFunction("scheduleCollapse", "collapseReactionsPicker");
     }


### PR DESCRIPTION
Prior to this change, click on counter the state panel would show, moving mouse to the panel you could for a very short moment go over the emoji button and trigger a picker expand which would collapse the panel. This change makes it much less likely to happen.