### PR TITLE
FIX: simplify popper lifecycle

### DIFF
--- a/assets/javascripts/discourse/widgets/discourse-reactions-actions.js
+++ b/assets/javascripts/discourse/widgets/discourse-reactions-actions.js
@@ -626,16 +626,6 @@ export default createWidget("discourse-reactions-actions", {
         } ${selectors[1]}`
       );
 
-      // we only keep one popper instance for simplicity
-      // so we could destroy it before the class is actually removed
-      // in this case the popper would stay at a bad position until
-      // the class would be removed
-      const existingPopper = _popperPicker?.state?.elements?.popper;
-      if (existingPopper && existingPopper !== popperElement) {
-        existingPopper.classList.remove("is-expanded");
-      }
-
-      _popperPicker?.destroy();
       _popperPicker = this._applyPopper(trigger, popperElement);
     });
   },


### PR DESCRIPTION
This also prevents a bug under firefox where the reactions picker could flash for a very short time.