### PR TITLE
FIX: stores reference to expanded widget

### DIFF
--- a/assets/javascripts/discourse/widgets/discourse-reactions-actions.js
+++ b/assets/javascripts/discourse/widgets/discourse-reactions-actions.js
@@ -11,6 +11,11 @@ import bootbox from "bootbox";
 const VIBRATE_DURATION = 5;
 
 let _popperPicker;
+let _currentReactionWidget;
+
+export function resetCurrentReaction() {
+  _currentReactionWidget = null;
+}
 
 function buildFakeReaction(reactionId) {
   const img = document.createElement("img");
@@ -614,8 +619,6 @@ export default createWidget("discourse-reactions-actions", {
   },
 
   _setupPopper(selectors) {
-    _popperPicker?.state?.elements?.popper?.classList?.remove("is-expanded");
-
     schedule("afterRender", () => {
       const position = this.attrs.position || "right";
       const id = this.attrs.post.id;
@@ -626,8 +629,10 @@ export default createWidget("discourse-reactions-actions", {
         `#discourse-reactions-actions-${id}-${position} ${selectors[1]}`
       );
 
+      _currentReactionWidget?.collapseAllPanels();
       _popperPicker?.destroy();
       _popperPicker = this._applyPopper(trigger, popper);
+      _currentReactionWidget = this;
     });
   },
 

--- a/assets/javascripts/discourse/widgets/discourse-reactions-counter.js
+++ b/assets/javascripts/discourse/widgets/discourse-reactions-counter.js
@@ -3,8 +3,6 @@ import { iconNode } from "discourse-common/lib/icon-library";
 import { createWidget } from "discourse/widgets/widget";
 import CustomReaction from "../models/discourse-reactions-custom-reaction";
 
-let _popperStatePanel;
-
 export default createWidget("discourse-reactions-counter", {
   tagName: "div",
 
@@ -35,7 +33,6 @@ export default createWidget("discourse-reactions-counter", {
         this.state.reactionsUsers[reactionUser.id] = reactionUser.users;
       });
 
-      _popperStatePanel?.update();
       this.scheduleRerender();
       this.callWidgetFunction("updatePopperPosition");
     });

--- a/assets/javascripts/initializers/discourse-reactions.js
+++ b/assets/javascripts/initializers/discourse-reactions.js
@@ -1,3 +1,4 @@
+import { resetCurrentReaction } from "discourse/plugins/discourse-reactions/discourse/widgets/discourse-reactions-actions";
 import { withPluginApi } from "discourse/lib/plugin-api";
 import { replaceIcon } from "discourse-common/lib/icon-library";
 import { emojiUrlFor } from "discourse/lib/text";
@@ -134,5 +135,9 @@ export default {
     if (siteSettings.discourse_reactions_enabled) {
       withPluginApi("0.10.1", initializeDiscourseReactions);
     }
+  },
+
+  teardown() {
+    resetCurrentReaction();
   },
 };

--- a/assets/stylesheets/common/discourse-reactions.scss
+++ b/assets/stylesheets/common/discourse-reactions.scss
@@ -112,11 +112,9 @@ html.discourse-reactions-no-select {
   z-index: z("usercard") - 2;
   position: absolute;
   visibility: hidden;
-  display: none;
   padding: 15px 0;
 
   &.is-expanded {
-    display: block;
     visibility: visible;
   }
 
@@ -176,12 +174,10 @@ html.discourse-reactions-no-select {
   position: absolute;
   visibility: hidden;
   padding: 15px 0;
-  display: none;
 
   &.is-expanded {
     min-width: 80px;
     visibility: visible;
-    display: block;
   }
 
   .discourse-reactions-state-panel-reaction .count {


### PR DESCRIPTION
It allows for a more accurate targeting of the previous popper to collapse when a different reaction panel is opened