### PR TITLE
FIX: max reactions reached error message should be at par with core

### DIFF
--- a/assets/javascripts/discourse/widgets/discourse-reactions-actions.js
+++ b/assets/javascripts/discourse/widgets/discourse-reactions-actions.js
@@ -682,10 +682,10 @@ export default createWidget("discourse-reactions-actions", {
       xhr.status === 429 &&
       xhr.responseJSON &&
       xhr.responseJSON.extras &&
-      xhr.responseJSON.extras.wait_seconds
+      xhr.responseJSON.extras.time_left
     ) {
       return I18n.t("discourse_reactions.reaction.too_many_request", {
-        count: xhr.responseJSON.extras.wait_seconds,
+        time_left: xhr.responseJSON.extras.time_left,
       });
     } else if (xhr.status === 403) {
       return I18n.t("discourse_reactions.reaction.forbidden");

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -10,9 +10,7 @@ en:
       state_panel:
         more_users: "and %{count} more..."
       reaction:
-        too_many_request:
-          one: "You have been reacting a bit too fast, try again in %{count} second."
-          other: "You have been reacting a bit too fast, try again in %{count} seconds."
+        too_many_request: "You’ve reached the maximum daily reactions for today, but as you gain trust levels, you’ll earn more daily reactions. You’ll be able to react to posts again in %{time_left}."
         forbidden: "That reaction was created too long ago. It can no longer be modified or removed."
       picker:
         react_with: "React to this post with: %{reaction}"
@@ -23,7 +21,7 @@ en:
         remove: "Remove this like"
         cant_remove: "You can’t remove this like"
     notifications:
-      reaction: 
+      reaction:
         single: "<span>%{username}</span> %{description}"
         multiple: "<span>%{username}</span> reacted to %{count} of your posts"
       reaction_2: "<span class='double-user'>%{username}, %{username2}</span> %{description}"


### PR DESCRIPTION
https://meta.discourse.org/t/improve-copy-of-reaction-limit-reached-text/226718