### PR TITLE
FIX: Show not-allowed cursor if topic is archived

### DIFF
--- a/assets/javascripts/discourse/widgets/discourse-reactions-actions.js
+++ b/assets/javascripts/discourse/widgets/discourse-reactions-actions.js
@@ -148,8 +148,8 @@ export default createWidget("discourse-reactions-actions", {
     }
 
     if (
-      !post.current_user_reaction ||
-      (post.current_user_reaction.can_undo && post.likeAction.canToggle)
+      (!post.current_user_reaction || post.current_user_reaction.can_undo) &&
+      post.likeAction.canToggle
     ) {
       classes.push("can-toggle-reaction");
     }

--- a/assets/stylesheets/common/discourse-reactions.scss
+++ b/assets/stylesheets/common/discourse-reactions.scss
@@ -326,6 +326,20 @@ html.discourse-reactions-no-select {
     }
   }
 
+  &.can-toggle-reaction {
+    .discourse-reactions-reaction-button .reaction-button,
+    .discourse-reactions-reaction-button {
+      cursor: pointer;
+    }
+  }
+
+  &:not(.can-toggle-reaction) {
+    .discourse-reactions-reaction-button .reaction-button,
+    .discourse-reactions-reaction-button {
+      cursor: not-allowed;
+    }
+  }
+
   &.has-reacted {
     .discourse-no-touch & {
       .discourse-reactions-double-button:hover {
@@ -361,11 +375,6 @@ html.discourse-reactions-no-select {
           background: var(--primary-low);
         }
       }
-
-      .discourse-reactions-reaction-button .reaction-button,
-      .discourse-reactions-reaction-button {
-        cursor: not-allowed;
-      }
     }
   }
 
@@ -392,10 +401,6 @@ html.discourse-reactions-no-select {
 
           background: var(--love-low);
         }
-      }
-
-      .discourse-reactions-reaction-button {
-        cursor: pointer;
       }
     }
   }


### PR DESCRIPTION
The logic for showing the not-allowed cursor did not cover the edge
case when the user has not reacted yet, but they cannot either because
the topic does not allow.

This is related to https://github.com/discourse/discourse/pull/17951.