### PR TITLE
UX: Remove unnecessary li tag for user-activity-bottom plugin outlet

### DIFF
--- a/assets/javascripts/discourse/templates/connectors/user-activity-bottom/discourse-reactions-user-activity-reactions.hbs
+++ b/assets/javascripts/discourse/templates/connectors/user-activity-bottom/discourse-reactions-user-activity-reactions.hbs
@@ -1,8 +1,6 @@
 {{#if siteSettings.discourse_reactions_enabled}}
-  <li>
-    {{#link-to "userActivity.reactions"}}
-      {{d-icon "far-smile"}}
-      <span>{{i18n "discourse_reactions.reactions_title"}}</span>
-    {{/link-to}}
-  </li>
+  {{#link-to "userActivity.reactions"}}
+    {{d-icon "far-smile"}}
+    <span>{{i18n "discourse_reactions.reactions_title"}}</span>
+  {{/link-to}}
 {{/if}}


### PR DESCRIPTION
The plugin outlet is already wrapped in a `li` tag

https://github.com/discourse/discourse/blob/c0037dc0f06f08bd050aedc8aad97d1f05b322ab/app/assets/javascripts/discourse/app/templates/user/activity.hbs#L69