### PR TITLE
UX: Remove unnecessary li tag for plugin outlet

### DIFF
--- a/assets/javascripts/discourse/templates/connectors/user-notifications-bottom/discourse-reactions-user-notification-reactions.hbs
+++ b/assets/javascripts/discourse/templates/connectors/user-notifications-bottom/discourse-reactions-user-notification-reactions.hbs
@@ -1,8 +1,6 @@
 {{#if siteSettings.discourse_reactions_enabled}}
-  <li>
-    {{#link-to "userNotifications.reactionsReceived"}}
-      {{d-icon "far-smile"}}
-      <span>{{i18n "discourse_reactions.reactions_title"}}</span>
-    {{/link-to}}
-  </li>
+  {{#link-to "userNotifications.reactionsReceived"}}
+    {{d-icon "far-smile"}}
+    <span>{{i18n "discourse_reactions.reactions_title"}}</span>
+  {{/link-to}}
 {{/if}}


### PR DESCRIPTION
See https://github.com/discourse/discourse/blob/d5f6262c4fba45b59298e5677b3e551e03813185/app/assets/javascripts/discourse/app/templates/user/notifications.hbs#L77