### PR TITLE
FIX: handle rate limit error messages on server side

### DIFF
--- a/assets/javascripts/discourse/widgets/discourse-reactions-actions.js
+++ b/assets/javascripts/discourse/widgets/discourse-reactions-actions.js
@@ -680,12 +680,10 @@ export default createWidget("discourse-reactions-actions", {
     if (
       xhr.status === 429 &&
       xhr.responseJSON &&
-      xhr.responseJSON.extras &&
-      xhr.responseJSON.extras.time_left
+      xhr.responseJSON.errors &&
+      xhr.responseJSON.errors[0]
     ) {
-      return I18n.t("discourse_reactions.reaction.too_many_request", {
-        time_left: xhr.responseJSON.extras.time_left,
-      });
+      return xhr.responseJSON.errors[0];
     } else if (xhr.status === 403) {
       return I18n.t("discourse_reactions.reaction.forbidden");
     } else {

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -10,7 +10,6 @@ en:
       state_panel:
         more_users: "and %{count} more..."
       reaction:
-        too_many_request: "You’ve reached the maximum daily reactions for today, but as you gain trust levels, you’ll earn more daily reactions. You’ll be able to react to posts again in %{time_left}."
         forbidden: "That reaction was created too long ago. It can no longer be modified or removed."
       picker:
         react_with: "React to this post with: %{reaction}"

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -1,4 +1,6 @@
 en:
+  rate_limiter:
+    too_many_requests: "You have been reacting a bit too fast. Please wait %{time_left} before trying again."
   site_settings:
     discourse_reactions_like_icon: "Defines the icon used for the main reaction button."
     discourse_reactions_reaction_for_like: "Defines the reaction associated to to the like action."


### PR DESCRIPTION
Instead of handling rate limit error messages on the client side, rely on messages passed on from the server side. This fixes the same error being shown for both rate limiting and respecting the `max likes per day` site setting.