### PR TITLE
FIX: deleted topic should exclude it from reactions given

### DIFF
--- a/app/controllers/discourse_reactions/custom_reactions_controller.rb
+++ b/app/controllers/discourse_reactions/custom_reactions_controller.rb
@@ -34,7 +34,7 @@ module DiscourseReactions
 
       reaction_users = DiscourseReactions::ReactionUser
         .joins(:reaction, :post)
-        .joins("INNER JOIN topics t ON t.id = posts.topic_id")
+        .joins("INNER JOIN topics t ON t.id = posts.topic_id AND t.deleted_at IS NULL")
         .joins("LEFT JOIN categories c ON c.id = t.category_id")
         .includes(:user, :post, :reaction)
         .where(user_id: user.id)

--- a/spec/requests/custom_reactions_controller_spec.rb
+++ b/spec/requests/custom_reactions_controller_spec.rb
@@ -204,7 +204,7 @@ describe DiscourseReactions::CustomReactionsController do
       end
     end
 
-    context "When op containing reactions is destroyed" do
+    context "when op containing reactions is destroyed" do
       fab!(:topic) { create_topic }
       fab!(:op) { Fabricate(:post, topic: topic) }
 


### PR DESCRIPTION
The specific reported bug was about deleting the OP of a topic which would in return delete the associated topic and cause an error when visiting: `/u/:username/activity/reactions`