### PR TITLE
UX: Update reaction badge icon

### DIFF
--- a/db/fixtures/001_badges.rb
+++ b/db/fixtures/001_badges.rb
@@ -15,7 +15,7 @@ SQL
 
 Badge.seed(:name) do |b|
   b.name = "First Reaction"
-  b.default_icon = "far-smile"
+  b.default_icon = "smile"
   b.badge_type_id = BadgeType::Bronze
   b.multiple_grant = false
   b.target_posts = true

--- a/db/migrate/20230227050149_update_reaction_badge_icon.rb
+++ b/db/migrate/20230227050149_update_reaction_badge_icon.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class UpdateReactionBadgeIcon < ActiveRecord::Migration[7.0]
+  def change
+    execute "UPDATE badges SET icon = 'smile' WHERE name = 'First Reaction'"
+  end
+end

--- a/db/migrate/20230227050149_update_reaction_badge_icon.rb
+++ b/db/migrate/20230227050149_update_reaction_badge_icon.rb
@@ -2,6 +2,6 @@
 
 class UpdateReactionBadgeIcon < ActiveRecord::Migration[7.0]
   def change
-    execute "UPDATE badges SET icon = 'smile' WHERE name = 'First Reaction'"
+    execute "UPDATE badges SET icon = 'smile' WHERE name = 'First Reaction' and icon = 'far-smile'"
   end
 end


### PR DESCRIPTION
Used to be 

<img width="135" alt="Screenshot 2023-02-27 at 5 51 01 PM" src="https://user-images.githubusercontent.com/1555215/221530807-597123b4-a1d2-4ab0-9385-1768080758a3.png">

and now will be 

<img width="136" alt="Screenshot 2023-02-27 at 5 52 27 PM" src="https://user-images.githubusercontent.com/1555215/221531100-efae1b67-b32c-42e4-8b5c-73b0ac897161.png">

with @chapoi's suggestion. 

Related: Related: https://meta.discourse.org/t/badges-on-meta/256289
