### PR TITLE
Revert "UX: Adjust styling (#214)"

### DIFF
--- a/assets/stylesheets/common/discourse-reactions.scss
+++ b/assets/stylesheets/common/discourse-reactions.scss
@@ -200,14 +200,12 @@ html.discourse-reactions-no-select {
     flex-direction: column;
     z-index: 1;
     padding: 0.25em;
-    border-radius: 8px;
+    border: 1px solid var(--primary-low);
   }
 
   .counters {
     display: flex;
     flex-direction: column;
-    max-height: 200px;
-    overflow-y: scroll;
   }
 }
 


### PR DESCRIPTION
This reverts commit 9a8045434745b11ddebd3cda0b388499fef22fed.

A vertical scrollbar is being shown even when reactions fit into a single line.

![Peek 2023-03-09 08-54](https://user-images.githubusercontent.com/4335742/223887133-dae52fd1-9e2d-4b63-bb07-5fb048bcf83e.gif)
