### PR TITLE
SECURITY: Publish reactions based on topic permissions

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -2,7 +2,7 @@
 
 # name: discourse-reactions
 # about: Allows users to react with emojis to a post
-# version: 0.2
+# version: 0.3
 # author: Ahmed Gagan, Rafael dos Santos Silva, Kris Aubuchon, Joffrey Jaffeux, Kris Kotlarek, Jordan Vidrine
 # url: https://github.com/discourse/discourse-reactions
 # transpile_js: true


### PR DESCRIPTION
Only show post reactions to users that have permission to see the post.