### PR TITLE
PERF: replace `pluck` with a `select`

### DIFF
--- a/app/controllers/discourse_reactions/custom_reactions_controller.rb
+++ b/app/controllers/discourse_reactions/custom_reactions_controller.rb
@@ -82,7 +82,7 @@ class DiscourseReactions::CustomReactionsController < ApplicationController
 
     posts = Post.joins(:topic).where(user_id: user.id)
     posts = guardian.filter_allowed_categories(posts)
-    post_ids = posts.pluck(:id)
+    post_ids = posts.select(:id)
 
     reaction_users =
       DiscourseReactions::ReactionUser


### PR DESCRIPTION
So we let the database do the work rather than retrieving a huge (for active posters) list of ids and sending it back to the database twice 😬

With the `pluck`, we ask the database to send back to Ruby the list of the all post ids the user has created.
Then we send that list twice to the database (because we're doing 2 queries based on those ids).

With the `select`, we send a sub-query to the database and all the work is done locally. Much faster and there's no need to send the list of all the post ids to Ruby and back to the database.

Was initially added in b9364574fea8b3a01cdd5d30dc46bb4fde591ca2.

Not tests since no behaviour was changed, it's "just" a query optimization.