### PR TITLE
UX: constrain avatars to container to avoid overflow

### DIFF
--- a/assets/stylesheets/common/discourse-reactions.scss
+++ b/assets/stylesheets/common/discourse-reactions.scss
@@ -245,11 +245,16 @@ html.discourse-reactions-no-select {
     flex-direction: column;
 
     .trigger-user-card {
-      width: 22.5px;
-      height: 22.5px;
+      width: 22px;
+      height: 22px;
       display: flex;
       align-items: center;
       justify-content: center;
+      .avatar {
+        // constrain to container
+        width: 100%;
+        height: 100%;
+      }
     }
   }
 


### PR DESCRIPTION
This fixes an issue where horizontal scroll would happen due to some core changes in https://github.com/discourse/discourse/commit/c2332d7505379c30e11d295d90f5224385736993

as seen here:
![image](https://github.com/discourse/discourse-reactions/assets/1681963/f98c868c-e7ac-4a6c-9a3f-e7c54d14662d)


the fix constrains the avatar images to fit their container, which should prevent this overflow from happening no matter what size the avatars are 