### PR TITLE
FIX: prevents triggering a reaction while scrolling

### DIFF
--- a/assets/javascripts/discourse/widgets/discourse-reactions-actions.js
+++ b/assets/javascripts/discourse/widgets/discourse-reactions-actions.js
@@ -168,6 +168,8 @@ export default createWidget("discourse-reactions-actions", {
   },
 
   touchStart() {
+    this._validTouch = true;
+
     cancel(this._touchTimeout);
     if (this.capabilities.touch) {
       const root = document.getElementsByTagName("html")[0];
@@ -182,8 +184,19 @@ export default createWidget("discourse-reactions-actions", {
     }
   },
 
+  touchMove(event) {
+    // if users move while touching we consider it as a scroll and don't want to
+    // trigger the reaction or the picker
+    this._validTouch = false;
+    cancel(this._touchTimeout);
+  },
+
   touchEnd(event) {
     cancel(this._touchTimeout);
+
+    if (!this._validTouch) {
+      return;
+    }
 
     const root = document.getElementsByTagName("html")[0];
     root && root.classList.remove("discourse-reactions-no-select");

--- a/assets/javascripts/discourse/widgets/discourse-reactions-actions.js
+++ b/assets/javascripts/discourse/widgets/discourse-reactions-actions.js
@@ -184,7 +184,7 @@ export default createWidget("discourse-reactions-actions", {
     }
   },
 
-  touchMove(event) {
+  touchMove() {
     // if users move while touching we consider it as a scroll and don't want to
     // trigger the reaction or the picker
     this._validTouch = false;


### PR DESCRIPTION
It's a simple hack to mark a current touch sequence touchstart/touchend as invalid if the user has been moving finger (scrolling most likely) during start and end.

Not it will require https://github.com/discourse/discourse/pull/22635 to be merged for this to work, but it will just do nothing and not error if the commit is not present as `touchMove` won't be called in this case.