### PR TITLE
UX: minor alignment adjustments

### DIFF
--- a/assets/stylesheets/common/discourse-reactions.scss
+++ b/assets/stylesheets/common/discourse-reactions.scss
@@ -321,15 +321,15 @@ html.discourse-reactions-no-select {
     margin-left: 0 !important; // core rule has too much specificity
   }
 
-  // manually account for emoji not being a perfect square
-  .reactions-counter {
-    padding-top: 2px;
-  }
-
   &:not(.custom-reaction-used) {
     .discourse-reactions-counter {
-      padding-right: 0;
-      padding-left: 15px;
+      padding: 8px 0 8px 10px;
+      line-height: 1;
+      + .discourse-reactions-reaction-button {
+        button {
+          padding-left: 0.45em;
+        }
+      }
     }
   }
 
@@ -442,7 +442,7 @@ html.discourse-reactions-no-select {
   align-items: center;
   text-align: center;
   cursor: pointer;
-  padding: 0 10px;
+  padding: 0 10px 0 0;
 
   .reactions-counter {
     font-size: $font-up-1;


### PR DESCRIPTION
Before (read count is at a different height, too much space on left of reaction button):
![Screenshot 2023-07-28 at 4 52 38 PM](https://github.com/discourse/discourse-reactions/assets/1681963/27c5c26a-afdf-47f9-8876-e1dc47d77b86)

After (counts aligned, no more extra space):
![Screenshot 2023-07-28 at 3 57 59 PM](https://github.com/discourse/discourse-reactions/assets/1681963/cfb413a9-a488-4073-9d68-080ba0253d26)
