### PR TITLE
UX: follow-up padding adjustment

### DIFF
--- a/assets/stylesheets/common/discourse-reactions.scss
+++ b/assets/stylesheets/common/discourse-reactions.scss
@@ -323,13 +323,15 @@ html.discourse-reactions-no-select {
 
   &:not(.custom-reaction-used) {
     .discourse-reactions-counter {
-      padding: 8px 0 8px 10px;
       line-height: 1;
       + .discourse-reactions-reaction-button {
         button {
           padding-left: 0.45em;
         }
       }
+    }
+    .reactions-counter {
+      padding: 8px 0 8px 10px;
     }
   }
 

--- a/assets/stylesheets/common/discourse-reactions.scss
+++ b/assets/stylesheets/common/discourse-reactions.scss
@@ -442,7 +442,6 @@ html.discourse-reactions-no-select {
   align-items: center;
   text-align: center;
   cursor: pointer;
-  padding: 0 10px 0 0;
 
   .reactions-counter {
     font-size: $font-up-1;


### PR DESCRIPTION
Minor follow-up to b762aeb, the way the padding was positioned on the button container instead of the child was causing an alignment issue on own-posts due to some other custom post buttons. This helps avoid the issue.

Before:
![Screenshot 2023-07-31 at 10 52 47 AM](https://github.com/discourse/discourse-reactions/assets/1681963/ead1e329-fb73-409a-8c66-0fd2dad95055)

After:
![Screenshot 2023-07-31 at 10 53 11 AM](https://github.com/discourse/discourse-reactions/assets/1681963/2e7cb78c-e889-4794-9c62-ce50ba95a3f7)

