### PR TITLE
FIX: Display correct title text for unauthenticated users

### DIFF
--- a/assets/javascripts/discourse/widgets/discourse-reactions-reaction-button.js
+++ b/assets/javascripts/discourse/widgets/discourse-reactions-reaction-button.js
@@ -50,6 +50,12 @@ export default createWidget("discourse-reactions-reaction-button", {
   },
 
   buildAttributes(attrs) {
+    if (!this.currentUser) {
+      return {
+        title: I18n.t("discourse_reactions.main_reaction.unauthenticated"),
+      };
+    }
+
     const likeAction = attrs.post.likeAction;
     if (!likeAction) {
       return {};

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -19,6 +19,7 @@ en:
         add: "Like this post"
         remove: "Remove this like"
         cant_remove: "You can no longer remove your like"
+        unauthenticated: "Please sign up or log in to like this post"
     notifications:
       reaction_1_user_multiple_posts: "reacted to %{count} of your posts"
       reaction_2_users: "%{username}, %{username2}"


### PR DESCRIPTION
[Meta](https://meta.discourse.org/t/wrong-tooltip-on-like-button-for-non-registered-user/273896).

### What was the issue?

Unauthenticated users would incorrectly see this title text when hovering the reaction button:

<img width="247" alt="Screenshot 2023-08-10 at 11 33 05 AM" src="https://github.com/discourse/discourse-reactions/assets/5259935/d300f7a9-aea2-4cb2-b5d1-8b2defe7c746">

### How does this fix it?

This change adds a new translation key and uses it when user is authenticated:

<img width="270" alt="Screenshot 2023-08-10 at 11 32 43 AM" src="https://github.com/discourse/discourse-reactions/assets/5259935/0ab506cd-3b05-4ec9-a45e-2b8ac15d77e0">

### Should there be a test for this?

I am on the fence. Should QUnit/system tests go to the granularity of title texts? I'm happy to add it if there's a compelling case made. WDYT?