### PR TITLE
FIX: Support older versions of core in JS intializer

### DIFF
--- a/assets/javascripts/initializers/discourse-reactions.js
+++ b/assets/javascripts/initializers/discourse-reactions.js
@@ -11,16 +11,30 @@ const PLUGIN_ID = "discourse-reactions";
 replaceIcon("notification.reaction", "bell");
 
 function initializeDiscourseReactions(api) {
-  api.replacePostMenuButton("like", {
-    name: "discourse-reactions-actions",
-    buildAttrs: (widget) => {
-      return { post: widget.findAncestorModel() };
-    },
-    shouldRender: (widget) => {
-      const post = widget.findAncestorModel();
-      return post && !post.deleted_at;
-    },
-  });
+  if (api.replacePostMenuButton) {
+    api.replacePostMenuButton("like", {
+      name: "discourse-reactions-actions",
+      buildAttrs: (widget) => {
+        return { post: widget.findAncestorModel() };
+      },
+      shouldRender: (widget) => {
+        const post = widget.findAncestorModel();
+        return post && !post.deleted_at;
+      },
+    });
+  } else {
+    api.removePostMenuButton("like");
+    api.decorateWidget("post-menu:before-extra-controls", (dec) => {
+      const post = dec.getModel();
+      if (!post || post.deleted_at) {
+        return;
+      }
+
+      return dec.attach("discourse-reactions-actions", {
+        post,
+      });
+    });
+  }
 
   api.addKeyboardShortcut("l", null, {
     click: ".topic-post.selected .discourse-reactions-reaction-button",


### PR DESCRIPTION
In [this commit](https://github.com/discourse/discourse-reactions/commit/d837405b4a29bc6ec6ddb0e4005b6fe62ea4c451) I swapped out logic that relies on a new plugin API method. If you're pinned to stable, the plugin now breaks. 

This PR adds backwards compatability.