### PR TITLE
DEV: Backfill test for report fix

### DIFF
--- a/spec/reports/reactions_spec.rb
+++ b/spec/reports/reactions_spec.rb
@@ -38,4 +38,30 @@ describe Report do
     post_action_data = report.data.find { |x| x[:day] === 1.day.ago.to_date }
     expect(post_action_data[:like_count]).to eq(2)
   end
+
+  it "includes reactions on the start dates and end dates" do
+    reaction_cat = Fabricate(:reaction, post: post_1, reaction_value: "cat")
+    Fabricate(
+      :reaction_user,
+      reaction: reaction_cat,
+      user: user_1,
+      post: post_1,
+      created_at: 2.days.ago,
+    )
+    Fabricate(
+      :reaction_user,
+      reaction: reaction_cat,
+      user: user_2,
+      post: post_1,
+      created_at: Time.current,
+    )
+
+    report = Report.find("reactions", start_date: 2.days.ago, end_date: Time.current)
+
+    expect(report.data).to contain_exactly(
+      a_hash_including("cat_count" => 1, :day => 2.days.ago.to_date, :like_count => 0),
+      a_hash_including(day: 1.days.ago.to_date, like_count: 0),
+      a_hash_including("cat_count" => 1, :day => Time.current.to_date, :like_count => 0),
+    )
+  end
 end


### PR DESCRIPTION

This adds a test which ensures the start date and end date are included in the report, which was fixed in https://github.com/discourse/discourse-reactions/pull/235