### PR TITLE
DEV: Add system specs for reaction notifications

### DIFF
--- a/spec/fabricators/reaction_notification_fabricator.rb
+++ b/spec/fabricators/reaction_notification_fabricator.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+Fabricator(:one_reaction_notification, from: :notification) do
+  transient :acting_user
+  notification_type Notification.types[:reaction]
+  post
+  topic { |attrs| attrs[:post].topic }
+  data do |attrs|
+    acting_user = attrs[:acting_user] || Fabricate(:user)
+    {
+      topic_title: attrs[:topic].title,
+      original_post_id: attrs[:post].id,
+      original_post_type: attrs[:post].post_type,
+      original_username: acting_user.username,
+      revision_number: nil,
+      display_username: acting_user.username,
+    }.to_json
+  end
+end
+
+Fabricator(:multiple_reactions_notification, from: :one_reaction_notification) do
+  transient :acting_user_2
+  transient :count
+  data do |attrs|
+    acting_user = attrs[:acting_user] || Fabricate(:user)
+    acting_user_2 = attrs[:acting_user_2] || Fabricate(:user)
+    {
+      topic_title: attrs[:topic].title,
+      original_post_id: attrs[:post].id,
+      original_post_type: attrs[:post].post_type,
+      original_username: acting_user_2.username,
+      revision_number: nil,
+      display_username: acting_user_2.username,
+      previous_notification_id: 2019,
+      username2: acting_user.username,
+      count: attrs[:count] || 2,
+    }.to_json
+  end
+end

--- a/spec/system/reaction_notifications_spec.rb
+++ b/spec/system/reaction_notifications_spec.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+describe "Reactions | Notifications", type: :system, js: true do
+  fab!(:current_user) { Fabricate(:user) }
+  fab!(:acting_user_1) { Fabricate(:user) }
+  fab!(:acting_user_2) { Fabricate(:user) }
+
+  fab!(:one_reaction_notification) do
+    Fabricate(:one_reaction_notification, user: current_user, acting_user: acting_user_1)
+  end
+
+  fab!(:two_reactions_notification) do
+    Fabricate(
+      :multiple_reactions_notification,
+      user: current_user,
+      count: 2,
+      acting_user: acting_user_1,
+      acting_user_2: acting_user_2,
+    )
+  end
+
+  fab!(:three_reactions_notification) do
+    Fabricate(
+      :multiple_reactions_notification,
+      user: current_user,
+      count: 3,
+      acting_user: acting_user_1,
+      acting_user_2: acting_user_2,
+    )
+  end
+
+  let(:user_menu) { PageObjects::Components::UserMenu.new }
+
+  before do
+    SiteSetting.discourse_reactions_enabled = true
+    sign_in(current_user)
+  end
+
+  it "renders reactions notifications correctly in the user menu" do
+    visit("/")
+
+    user_menu.open
+
+    expect(page).to have_css(
+      "#quick-access-all-notifications .notification.reaction .item-label",
+      count: 3,
+    )
+
+    labels = page.all("#quick-access-all-notifications .notification.reaction .item-label")
+    expect(labels[0]).to have_text(
+      I18n.t(
+        "js.notifications.reaction_multiple_users",
+        username: acting_user_2.username,
+        count: 2,
+      ),
+    )
+    expect(labels[1]).to have_text(
+      I18n.t(
+        "js.notifications.reaction_2_users",
+        username: acting_user_2.username,
+        username2: acting_user_1.username,
+      ),
+    )
+    expect(labels[2]).to have_text(acting_user_1.username)
+  end
+end


### PR DESCRIPTION
We've recently had a regression that broke the rendering of reaction notifications in the UI, so we're adding these system tests to ensure that we don't regress again.

Internal topic: t/111616.