### PR TITLE
DEV: Remove deprecated `showFooter` calls

### DIFF
--- a/assets/javascripts/discourse/controllers/user-activity-reactions.js
+++ b/assets/javascripts/discourse/controllers/user-activity-reactions.js
@@ -13,11 +13,6 @@ export default class UserActivityReactions extends Controller {
   @tracked beforeLikeId = null;
   @tracked beforeReactionUserId = null;
 
-  constructor() {
-    super(...arguments);
-    this.set("application.showFooter", !this.canLoadMore);
-  }
-
   #getLastIdFrom(array) {
     return array.length ? array[array.length - 1].get("id") : null;
   }
@@ -48,11 +43,6 @@ export default class UserActivityReactions extends Controller {
 
   @action
   loadMore() {
-    if (!this.canLoadMore || this.loading || !this.reactionsUrl) {
-      this.set("application.showFooter", !this.canLoadMore);
-      return;
-    }
-
     this.loading = true;
     const reactionUsers = this.model;
 

--- a/assets/javascripts/discourse/routes/user-activity-reactions.js
+++ b/assets/javascripts/discourse/routes/user-activity-reactions.js
@@ -17,6 +17,5 @@ export default class UserActivityReactions extends DiscourseRoute {
       reactionsUrl: "reactions",
       username: this.modelFor("user").get("username"),
     });
-    this.controllerFor("application").set("showFooter", loadedAll);
   }
 }


### PR DESCRIPTION
This is now handled in Discourse core via the `hide-application-footer` helper in the user-topics-list template