### PR TITLE
FIX: update post id for reactions when post is moved

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -345,18 +345,19 @@ after_initialize do
   register_notification_consolidation_plan(consolidated_reactions)
 
   on(:post_moved) do |post, original_topic_id, original_post_id|
-    params = { new_post_id: post.id, original_post_id: original_post_id }
+    next if original_post_id.nil?
+    params = { old_post_id: original_post_id, new_post_id: post.id }
 
     DB.exec(<<~SQL, params)
       UPDATE discourse_reactions_reactions
       SET post_id = :new_post_id
-      WHERE post_id = :original_post_id
+      WHERE post_id = :old_post_id
     SQL
 
     DB.exec(<<~SQL, params)
       UPDATE discourse_reactions_reaction_users
       SET post_id = :new_post_id
-      WHERE post_id = :original_post_id
+      WHERE post_id = :old_post_id
     SQL
   end
 end

--- a/plugin.rb
+++ b/plugin.rb
@@ -348,16 +348,18 @@ after_initialize do
     next if original_post_id.nil?
     params = { old_post_id: original_post_id, new_post_id: post.id }
 
-    DB.exec(<<~SQL, params)
-      UPDATE discourse_reactions_reactions
-      SET post_id = :new_post_id
-      WHERE post_id = :old_post_id
-    SQL
+    ActiveRecord::Base.transaction do
+      DB.exec(<<~SQL, params)
+        UPDATE discourse_reactions_reactions
+        SET post_id = :new_post_id
+        WHERE post_id = :old_post_id
+      SQL
 
-    DB.exec(<<~SQL, params)
-      UPDATE discourse_reactions_reaction_users
-      SET post_id = :new_post_id
-      WHERE post_id = :old_post_id
-    SQL
+      DB.exec(<<~SQL, params)
+        UPDATE discourse_reactions_reaction_users
+        SET post_id = :new_post_id
+        WHERE post_id = :old_post_id
+      SQL
+    end
   end
 end

--- a/plugin.rb
+++ b/plugin.rb
@@ -343,4 +343,20 @@ after_initialize do
 
   register_notification_consolidation_plan(reacted_by_two_users)
   register_notification_consolidation_plan(consolidated_reactions)
+
+  on(:post_moved) do |post, original_topic_id, original_post_id|
+    params = { new_post_id: post.id, original_post_id: original_post_id }
+
+    DB.exec(<<~SQL, params)
+      UPDATE discourse_reactions_reactions
+      SET post_id = :new_post_id
+      WHERE post_id = :original_post_id
+    SQL
+
+    DB.exec(<<~SQL, params)
+      UPDATE discourse_reactions_reaction_users
+      SET post_id = :new_post_id
+      WHERE post_id = :original_post_id
+    SQL
+  end
 end

--- a/spec/models/post_mover_spec.rb
+++ b/spec/models/post_mover_spec.rb
@@ -27,9 +27,8 @@ describe PostMover do
     expect(post_1.reactions).to include(reaction_1)
     expect(topic_2.posts.count).to eq(0)
 
-    expect {
-      topic_1.move_posts(admin, [post_1.id], { destination_topic_id: topic_2.id })
-    }.to change { topic_2.posts.count }.by(1)
+    post_mover = PostMover.new(topic_1, Discourse.system_user, [post_1.id])
+    expect { post_mover.to_topic(topic_2) }.to change { topic_2.posts.count }.by(1)
 
     expect(topic_2.posts.count).to eq(1)
 
@@ -44,9 +43,8 @@ describe PostMover do
     expect(post_2.reactions).to include(reaction_2)
     expect(topic_3.posts.count).to eq(0)
 
-    expect {
-      topic_1.move_posts(admin, [post_2.id], { destination_topic_id: topic_3.id })
-    }.to change { topic_3.posts.count }.by(1)
+    post_mover = PostMover.new(topic_1, Discourse.system_user, [post_2.id])
+    expect { post_mover.to_topic(topic_3) }.to change { topic_3.posts.count }.by(1)
 
     expect(topic_3.posts.count).to eq(1)
 

--- a/spec/models/post_mover_spec.rb
+++ b/spec/models/post_mover_spec.rb
@@ -1,9 +1,5 @@
 # frozen_string_literal: true
 
-require "rails_helper"
-require_relative "../fabricators/reaction_fabricator.rb"
-require_relative "../fabricators/reaction_user_fabricator.rb"
-
 describe PostMover do
   fab!(:admin) { Fabricate(:admin) }
   fab!(:user) { Fabricate(:user) }

--- a/spec/models/post_mover_spec.rb
+++ b/spec/models/post_mover_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require_relative "../fabricators/reaction_fabricator.rb"
+require_relative "../fabricators/reaction_user_fabricator.rb"
+
+describe PostMover do
+  fab!(:admin) { Fabricate(:admin) }
+  fab!(:user) { Fabricate(:user) }
+  fab!(:topic_1) { Fabricate(:topic, user: user) }
+  fab!(:topic_2) { Fabricate(:topic, user: user) }
+  fab!(:post_1) { Fabricate(:post, topic: topic_1, user: user) }
+  fab!(:post_2) { Fabricate(:post, topic: topic_1, user: user) }
+  fab!(:reaction_1) { Fabricate(:reaction, post: post_1, reaction_value: "clap") }
+  fab!(:reaction_2) { Fabricate(:reaction, post: post_2, reaction_value: "+1") }
+  fab!(:user_reaction_1) do
+    Fabricate(:reaction_user, user: admin, reaction: reaction_1, post: post_1)
+  end
+  fab!(:user_reaction_2) do
+    Fabricate(:reaction_user, user: admin, reaction: reaction_2, post: post_2)
+  end
+
+  before { SiteSetting.discourse_reactions_enabled = true }
+
+  it "moved post still has existing reactions" do
+    expect {
+      topic_1.move_posts(admin, [post_2.id], { destination_topic_id: topic_2.id })
+    }.to change { topic_2.posts.count }.by(1)
+
+    reaction_emojis = topic_2.posts.last.reactions.pluck(:reaction_value)
+    expect(reaction_emojis).to include("+1")
+  end
+
+  it "new post has topic's first post reactions (OP)" do
+    expect {
+      topic_1.move_posts(admin, [topic_1.first_post.id], { destination_topic_id: topic_2.id })
+    }.to change { topic_2.posts.count }.by(1)
+
+    reaction_emojis = topic_2.posts.last.reactions.pluck(:reaction_value)
+    expect(reaction_emojis).to include("clap")
+  end
+end

--- a/spec/models/post_mover_spec.rb
+++ b/spec/models/post_mover_spec.rb
@@ -9,10 +9,11 @@ describe PostMover do
   fab!(:user) { Fabricate(:user) }
   fab!(:topic_1) { Fabricate(:topic, user: user) }
   fab!(:topic_2) { Fabricate(:topic, user: user) }
+  fab!(:topic_3) { Fabricate(:topic, user: user) }
   fab!(:post_1) { Fabricate(:post, topic: topic_1, user: user) }
   fab!(:post_2) { Fabricate(:post, topic: topic_1, user: user) }
-  fab!(:reaction_1) { Fabricate(:reaction, post: post_1, reaction_value: "clap") }
-  fab!(:reaction_2) { Fabricate(:reaction, post: post_2, reaction_value: "+1") }
+  fab!(:reaction_1) { Fabricate(:reaction, post: post_1) }
+  fab!(:reaction_2) { Fabricate(:reaction, post: post_2) }
   fab!(:user_reaction_1) do
     Fabricate(:reaction_user, user: admin, reaction: reaction_1, post: post_1)
   end
@@ -22,21 +23,37 @@ describe PostMover do
 
   before { SiteSetting.discourse_reactions_enabled = true }
 
-  it "moved post still has existing reactions" do
+  it "new post has topic's first post reactions (OP)" do
+    expect(post_1.reactions).to include(reaction_1)
+    expect(topic_2.posts.count).to eq(0)
+
     expect {
-      topic_1.move_posts(admin, [post_2.id], { destination_topic_id: topic_2.id })
+      topic_1.move_posts(admin, [post_1.id], { destination_topic_id: topic_2.id })
     }.to change { topic_2.posts.count }.by(1)
 
-    reaction_emojis = topic_2.posts.last.reactions.pluck(:reaction_value)
-    expect(reaction_emojis).to include("+1")
+    expect(topic_2.posts.count).to eq(1)
+
+    new_post = topic_2.reload.posts.first
+    reaction_emojis = new_post.reactions.pluck(:reaction_value)
+
+    expect(new_post.reactions.count).to eq(1)
+    expect(reaction_emojis).to include(reaction_1.reaction_value)
   end
 
-  it "new post has topic's first post reactions (OP)" do
-    expect {
-      topic_1.move_posts(admin, [topic_1.first_post.id], { destination_topic_id: topic_2.id })
-    }.to change { topic_2.posts.count }.by(1)
+  it "moved post still has existing reactions" do
+    expect(post_2.reactions).to include(reaction_2)
+    expect(topic_3.posts.count).to eq(0)
 
-    reaction_emojis = topic_2.posts.last.reactions.pluck(:reaction_value)
-    expect(reaction_emojis).to include("clap")
+    expect {
+      topic_1.move_posts(admin, [post_2.id], { destination_topic_id: topic_3.id })
+    }.to change { topic_3.posts.count }.by(1)
+
+    expect(topic_3.posts.count).to eq(1)
+
+    new_post = topic_3.reload.posts.first
+    reaction_emojis = new_post.reactions.pluck(:reaction_value)
+
+    expect(new_post.reactions.count).to eq(1)
+    expect(reaction_emojis).to include(reaction_2.reaction_value)
   end
 end

--- a/spec/models/post_mover_spec.rb
+++ b/spec/models/post_mover_spec.rb
@@ -12,14 +12,14 @@ describe PostMover do
   fab!(:topic_3) { Fabricate(:topic, user: user) }
   fab!(:post_1) { Fabricate(:post, topic: topic_1, user: user) }
   fab!(:post_2) { Fabricate(:post, topic: topic_1, user: user) }
-  fab!(:reaction_1) { Fabricate(:reaction, post: post_1) }
-  fab!(:reaction_2) { Fabricate(:reaction, post: post_2) }
-  fab!(:user_reaction_1) do
-    Fabricate(:reaction_user, user: admin, reaction: reaction_1, post: post_1)
-  end
-  fab!(:user_reaction_2) do
-    Fabricate(:reaction_user, user: admin, reaction: reaction_2, post: post_2)
-  end
+  fab!(:reaction_1) { Fabricate(:reaction, post: post_1, reaction_value: "clap") }
+  fab!(:reaction_2) { Fabricate(:reaction, post: post_1, reaction_value: "confetti") }
+  fab!(:reaction_3) { Fabricate(:reaction, post: post_2, reaction_value: "heart") }
+  fab!(:reaction_4) { Fabricate(:reaction, post: post_2, reaction_value: "wave") }
+  fab!(:user_reaction_1) { Fabricate(:reaction_user, reaction: reaction_1, post: post_1) }
+  fab!(:user_reaction_2) { Fabricate(:reaction_user, reaction: reaction_2, post: post_1) }
+  fab!(:user_reaction_3) { Fabricate(:reaction_user, reaction: reaction_3, post: post_2) }
+  fab!(:user_reaction_4) { Fabricate(:reaction_user, reaction: reaction_4, post: post_2) }
 
   before { SiteSetting.discourse_reactions_enabled = true }
 
@@ -35,23 +35,29 @@ describe PostMover do
     new_post = topic_2.first_post
     reaction_emojis = new_post.reactions.pluck(:reaction_value)
 
-    expect(new_post.reactions.count).to eq(1)
-    expect(reaction_emojis).to include(reaction_1.reaction_value)
+    expect(reaction_emojis.count).to eq(2)
+    expect(reaction_emojis).to match_array([reaction_1.reaction_value, reaction_2.reaction_value])
+
+    reaction_user_ids = new_post.reactions_user.pluck(:user_id)
+    expect(reaction_user_ids.count).to eq(2)
+    expect(reaction_user_ids).to match_array([user_reaction_1.user_id, user_reaction_2.user_id])
   end
 
   it "moved post still has existing reactions" do
-    expect(post_2.reactions).to include(reaction_2)
+    expect(post_2.reactions).to include(reaction_3)
     expect(topic_3.posts.count).to eq(0)
 
     post_mover = PostMover.new(topic_1, Discourse.system_user, [post_2.id])
     expect { post_mover.to_topic(topic_3) }.to change { topic_3.posts.count }.by(1)
 
-    expect(topic_3.posts.count).to eq(1)
-
     new_post = topic_3.first_post
-    reaction_emojis = new_post.reactions.pluck(:reaction_value)
 
-    expect(new_post.reactions.count).to eq(1)
-    expect(reaction_emojis).to include(reaction_2.reaction_value)
+    # reaction id does not change as post is updated (unlike first post in topic)
+    expect(new_post.reactions.count).to eq(2)
+    expect(new_post.reactions).to match_array([reaction_3, reaction_4])
+
+    # reaction_user id does not change as post is updated (unlike first post in topic)
+    expect(new_post.reactions_user.count).to eq(2)
+    expect(new_post.reactions_user).to match_array([user_reaction_3, user_reaction_4])
   end
 end

--- a/spec/models/post_mover_spec.rb
+++ b/spec/models/post_mover_spec.rb
@@ -33,7 +33,7 @@ describe PostMover do
 
     expect(topic_2.posts.count).to eq(1)
 
-    new_post = topic_2.reload.posts.first
+    new_post = topic_2.first_post
     reaction_emojis = new_post.reactions.pluck(:reaction_value)
 
     expect(new_post.reactions.count).to eq(1)
@@ -50,7 +50,7 @@ describe PostMover do
 
     expect(topic_3.posts.count).to eq(1)
 
-    new_post = topic_3.reload.posts.first
+    new_post = topic_3.first_post
     reaction_emojis = new_post.reactions.pluck(:reaction_value)
 
     expect(new_post.reactions.count).to eq(1)

--- a/spec/models/post_mover_spec.rb
+++ b/spec/models/post_mover_spec.rb
@@ -19,8 +19,8 @@ describe PostMover do
 
   before { SiteSetting.discourse_reactions_enabled = true }
 
-  it "new post has topic's first post reactions (OP)" do
-    expect(post_1.reactions).to include(reaction_1)
+  it "should add old post's reactions to new post when a topic's first post is moved" do
+    expect(post_1.reactions).to contain_exactly(reaction_1, reaction_2)
     expect(topic_2.posts.count).to eq(0)
 
     post_mover = PostMover.new(topic_1, Discourse.system_user, [post_1.id])
@@ -39,8 +39,8 @@ describe PostMover do
     expect(reaction_user_ids).to match_array([user_reaction_1.user_id, user_reaction_2.user_id])
   end
 
-  it "moved post still has existing reactions" do
-    expect(post_2.reactions).to include(reaction_3)
+  it "should retain existing reactions after moving a post" do
+    expect(post_2.reactions).to contain_exactly(reaction_3, reaction_4)
     expect(topic_3.posts.count).to eq(0)
 
     post_mover = PostMover.new(topic_1, Discourse.system_user, [post_2.id])


### PR DESCRIPTION
Currently all emoji reactions on a post are lost when posts are moved to a new topic.

This change updates the reaction data post id to the new post.