### PR TITLE
FIX: skip adding reaction data if there are no reactions on OP

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -348,6 +348,8 @@ after_initialize do
     id_map = {}
     ActiveRecord::Base.transaction do
       reactions = DiscourseReactions::Reaction.where(post_id: original_post.id)
+      next if !reactions.any?
+
       reactions_attributes =
         reactions.map { |reaction| reaction.attributes.except("id").merge(post_id: target_post.id) }
       DiscourseReactions::Reaction

--- a/spec/models/post_mover_spec.rb
+++ b/spec/models/post_mover_spec.rb
@@ -19,6 +19,15 @@ describe PostMover do
 
   before { SiteSetting.discourse_reactions_enabled = true }
 
+  it "should create new post when topic's first post has no reactions" do
+    old_topic = Fabricate(:topic)
+    new_topic = Fabricate(:topic)
+    post = Fabricate(:post, topic: old_topic)
+
+    post_mover = PostMover.new(old_topic, Discourse.system_user, [post.id])
+    expect { post_mover.to_topic(new_topic) }.to change { new_topic.posts.count }.by(1)
+  end
+
   xit "should add old post's reactions to new post when a topic's first post is moved" do
     expect(post_1.reactions).to contain_exactly(reaction_1, reaction_2)
     expect(topic_2.posts.count).to eq(0)


### PR DESCRIPTION
There is a bug now when merging topics. If there are no reactions to a topic's first post then we should skip trying to add reaction data to it.

Introduced in: https://github.com/discourse/discourse-reactions/pull/250