### PR TITLE
FIX: missing reaction user for heart emoji breaks post mover

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -353,11 +353,14 @@ after_initialize do
 
       reactions_attributes =
         reactions.map { |reaction| reaction.attributes.except("id").merge(post_id: target_post.id) }
+
       DiscourseReactions::Reaction
         .insert_all(reactions_attributes)
         .each_with_index { |entry, index| id_map[reactions[index].id] = entry["id"] }
 
       reaction_users = DiscourseReactions::ReactionUser.where(post_id: original_post.id)
+      next if !reaction_users.any?
+
       reaction_users_attributes =
         reaction_users.map do |reaction_user|
           reaction_user
@@ -365,6 +368,7 @@ after_initialize do
             .except("id")
             .merge(post_id: target_post.id, reaction_id: id_map[reaction_user.reaction_id])
         end
+
       DiscourseReactions::ReactionUser.insert_all(reaction_users_attributes)
     end
   end


### PR DESCRIPTION
When a user reacts to a post it creates an entry for both the `discourse_reactions_reactions` and `discourse_reactions_reaction_users` tables.

However, when a post is liked using the :heart: emoji it still creates a `discourse_reactions_reactions` entry but stores user data within `post_actions` in core and doesn't create a `discourse_reactions_reaction_users` entry.

This change adds an extra check to skip adding `DiscourseReactions::ReactionUser` data if none is found.

The new test recreates the logic outlined above to assume that the post has a reaction and not the reaction user when it is liked, and should still work correctly.