### PR TITLE
FIX: Handle null post.user_id for UserAction sync

### DIFF
--- a/app/services/discourse_reactions/reaction_post_action_synchronizer.rb
+++ b/app/services/discourse_reactions/reaction_post_action_synchronizer.rb
@@ -74,7 +74,8 @@ module DiscourseReactions
                  post_actions.created_at
           FROM post_actions
           INNER JOIN posts ON posts.id = post_actions.post_id
-          WHERE post_actions.id IN (:post_action_ids);
+          WHERE post_actions.id IN (:post_action_ids) AND posts.user_id IS NOT NULL
+          ON CONFLICT DO NOTHING;
 
           INSERT INTO user_actions (
             action_type, user_id, acting_user_id, target_post_id, target_topic_id, created_at, updated_at
@@ -88,7 +89,8 @@ module DiscourseReactions
                  post_actions.created_at
           FROM post_actions
           INNER JOIN posts ON posts.id = post_actions.post_id
-          WHERE post_actions.id IN (:post_action_ids);
+          WHERE post_actions.id IN (:post_action_ids) AND posts.user_id IS NOT NULL
+          ON CONFLICT DO NOTHING;
         SQL
         DB.exec(
           sql_query,

--- a/spec/services/reaction_post_action_synchronizer_spec.rb
+++ b/spec/services/reaction_post_action_synchronizer_spec.rb
@@ -98,6 +98,12 @@ RSpec.describe DiscourseReactions::ReactionPostActionSynchronizer do
       ).to eq(true)
     end
 
+    it "skips UserAction records where the post has a null user" do
+      reaction_user_2.post.update_columns(user_id: nil)
+      SiteSetting.discourse_reactions_excluded_from_like = "-1" # clap removed
+      expect { described_class.sync! }.not_to change { UserAction.count }
+    end
+
     it "if no reactions are excluded from like it adds post actions for ones previously excluded" do
       SiteSetting.discourse_reactions_excluded_from_like = ""
       expect(reaction_user_2.post_action_like).to be_nil


### PR DESCRIPTION
There can be rare cases where a post user_id can be
NULL, this handles that case and also handles conflicts
when UserAction records are inserted that match existing
ones.
