### PR TITLE
FIX: Do not show users who Reacted under post ... menu

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -385,6 +385,23 @@ after_initialize do
     builder.where("discourse_reactions_reaction_users.id IS NULL")
   end
 
+  # Filter out the users who Liked as well as Reacted to the post, for the
+  # user avatars that show beneath the post when you click the "show more actions"
+  # [...] button.
+  register_modifier(:post_action_users_list) do |query, post|
+    where_clause = <<~SQL
+      post_actions.id NOT IN (
+        SELECT post_actions.id
+        FROM post_actions
+        INNER JOIN discourse_reactions_reaction_users ON discourse_reactions_reaction_users.post_id = post_actions.post_id
+          AND discourse_reactions_reaction_users.user_id = post_actions.user_id
+        WHERE post_actions.post_id = #{post.id}
+      )
+    SQL
+
+    query.where(where_clause)
+  end
+
   on(:first_post_moved) do |target_post, original_post|
     id_map = {}
     ActiveRecord::Base.transaction do

--- a/spec/requests/post_action_users_controller_spec.rb
+++ b/spec/requests/post_action_users_controller_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+RSpec.describe PostActionUsersController do
+  before { SiteSetting.discourse_reactions_enabled = true }
+
+  describe "post_action_users_list modifier for PostActionUsersController" do
+    fab!(:current_user) { Fabricate(:user) }
+    fab!(:user_1) { Fabricate(:user) }
+    fab!(:user_2) { Fabricate(:user) }
+    fab!(:post) { Fabricate(:post) }
+
+    before do
+      DiscourseReactions::ReactionManager.new(
+        reaction_value: "clap",
+        user: user_1,
+        post: post,
+      ).toggle!
+
+      DiscourseReactions::ReactionManager.new(
+        reaction_value: DiscourseReactions::Reaction.main_reaction_id,
+        user: user_2,
+        post: post,
+      ).toggle!
+    end
+
+    it "excludes users for a post who have a ReactionUser as well as a PostAction like" do
+      sign_in(current_user)
+      get "/post_action_users.json",
+          params: {
+            id: post.id,
+            post_action_type_id: PostActionType.types[:like],
+          }
+      expect(response.status).to eq(200)
+      expect(response.parsed_body["post_action_users"].map { |u| u["id"] }).to match_array(
+        [user_2.id],
+      )
+    end
+  end
+end


### PR DESCRIPTION
There is a "show-more-actions" button represented by ...
at the bottom of each post. This shows the users who have
liked the post. However, now that reactions also count as likes,
we don't want to show the users who reacted to the post here,
only the ones who liked it with main_reaction_id.

We can use the plugin modifier introduced in core in
https://github.com/discourse/discourse/pull/25740 for this.

![image](https://github.com/discourse/discourse-reactions/assets/920448/d2c01cfd-5898-4460-b177-82eec50c7b02)
