### PR TITLE
FIX: stop requesting more reactions when none exist

### DIFF
--- a/assets/javascripts/discourse/controllers/user-activity-reactions.js
+++ b/assets/javascripts/discourse/controllers/user-activity-reactions.js
@@ -43,6 +43,10 @@ export default class UserActivityReactions extends Controller {
 
   @action
   loadMore() {
+    if (!this.canLoadMore || this.loading) {
+      return;
+    }
+
     this.loading = true;
     const reactionUsers = this.model;
 


### PR DESCRIPTION
Prevents firing multiple ajax requests on scroll when no reactions exist.

_No test included currently as it's going to be tricky and it's a fairly minor fix, to test we would likely need to scroll the page to simulate the request to load more reactions._

Context:
https://meta.discourse.org/t/reactions-page-glitches-view-when-attempting-to-fetch-more-posts-where-no-more-posts-exist/292759?u=davidb