### PR TITLE
SECURITY: Hide whisper posts in reactions given endpoint

### DIFF
--- a/app/controllers/discourse_reactions/custom_reactions_controller.rb
+++ b/app/controllers/discourse_reactions/custom_reactions_controller.rb
@@ -48,8 +48,12 @@ class DiscourseReactions::CustomReactionsController < ApplicationController
 
     reaction_users =
       DiscourseReactions::ReactionUser
-        .joins(:reaction, :post)
-        .joins("INNER JOIN topics t ON t.id = posts.topic_id AND t.deleted_at IS NULL")
+        .joins(
+          "INNER JOIN discourse_reactions_reactions ON discourse_reactions_reactions.id = discourse_reactions_reaction_users.reaction_id",
+        )
+        .joins("INNER JOIN posts p ON p.id = discourse_reactions_reaction_users.post_id")
+        .joins("INNER JOIN topics t ON t.id = p.topic_id AND t.deleted_at IS NULL")
+        .joins("INNER JOIN posts p2 ON p2.topic_id = t.id AND p2.post_number = 1")
         .joins("LEFT JOIN categories c ON c.id = t.category_id")
         .includes(:user, :post, :reaction)
         .where(user_id: user.id)
@@ -271,8 +275,7 @@ class DiscourseReactions::CustomReactionsController < ApplicationController
 
   def secure_reaction_users!(reaction_users)
     builder = DB.build("/*where*/")
-    UserAction.filter_private_messages(builder, current_user.id, guardian)
-    UserAction.filter_categories(builder, guardian)
+    UserAction.apply_common_filters(builder, current_user.id, guardian)
     reaction_users.where(builder.to_sql.delete_prefix("/*where*/").delete_prefix("WHERE"))
   end
 

--- a/plugin.rb
+++ b/plugin.rb
@@ -3,7 +3,7 @@
 # name: discourse-reactions
 # about: Allows users to react to a post with emojis.
 # meta_topic_id: 183261
-# version: 0.3
+# version: 0.5
 # author: Ahmed Gagan, Rafael dos Santos Silva, Kris Aubuchon, Joffrey Jaffeux, Kris Kotlarek, Jordan Vidrine
 # url: https://github.com/discourse/discourse-reactions
 


### PR DESCRIPTION
Users who were not allowed to whisper could see reactions and whisper content of posts on public topics.