### PR TITLE
FIX: ensures activity/reactions doesnt show deleted

### DIFF
--- a/app/controllers/discourse_reactions/custom_reactions_controller.rb
+++ b/app/controllers/discourse_reactions/custom_reactions_controller.rb
@@ -51,9 +51,13 @@ class DiscourseReactions::CustomReactionsController < ApplicationController
         .joins(
           "INNER JOIN discourse_reactions_reactions ON discourse_reactions_reactions.id = discourse_reactions_reaction_users.reaction_id",
         )
-        .joins("INNER JOIN posts p ON p.id = discourse_reactions_reaction_users.post_id")
+        .joins(
+          "INNER JOIN posts p ON p.id = discourse_reactions_reaction_users.post_id AND p.deleted_at IS NULL",
+        )
         .joins("INNER JOIN topics t ON t.id = p.topic_id AND t.deleted_at IS NULL")
-        .joins("INNER JOIN posts p2 ON p2.topic_id = t.id AND p2.post_number = 1")
+        .joins(
+          "INNER JOIN posts p2 ON p2.topic_id = t.id AND p2.post_number = 1 AND p.deleted_at IS NULL",
+        )
         .joins("LEFT JOIN categories c ON c.id = t.category_id")
         .includes(:user, :post, :reaction)
         .where(user_id: user.id)

--- a/spec/system/reactions_activity_spec.rb
+++ b/spec/system/reactions_activity_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+describe "Reactions | Activity", type: :system, js: true do
+  fab!(:current_user) { Fabricate(:user) }
+
+  before do
+    SiteSetting.discourse_reactions_enabled = true
+    sign_in(current_user)
+  end
+
+  context "when current user reacts to a post" do
+    fab!(:post_1) { Fabricate(:post) }
+
+    before do
+      DiscourseReactions::ReactionManager.new(
+        reaction_value: "clap",
+        user: current_user,
+        post: post_1,
+      ).toggle!
+    end
+
+    it "shows in activity" do
+      visit("/u/#{current_user.username}/activity/reactions")
+
+      expect(page).to have_css(".user-stream-item [data-post-id='#{post_1.id}']")
+    end
+
+    context "when the associated post is deleted" do
+      before { post_1.trash! }
+
+      it "doesn't show it" do
+        visit("/u/#{current_user.username}/activity/reactions")
+
+        expect(page).to have_no_css(".user-stream-item [data-post-id='#{post_1.id}']")
+      end
+    end
+
+    context "when the associated topic is deleted" do
+      before { post_1.topic.trash! }
+
+      it "doesn't show it" do
+        visit("/u/#{current_user.username}/activity/reactions")
+
+        expect(page).to have_no_css(".user-stream-item [data-post-id='#{post_1.id}']")
+      end
+    end
+  end
+end


### PR DESCRIPTION
This fix ensures our query doesn't retrieve deleted posts which would cause an exception on the page when the js code would try to access the associated post which would be null in this case.