### PR TITLE
FIX: Reactions doubled up as like if no longer enabled

### DIFF
--- a/app/controllers/discourse_reactions/custom_reactions_controller.rb
+++ b/app/controllers/discourse_reactions/custom_reactions_controller.rb
@@ -172,7 +172,7 @@ class DiscourseReactions::CustomReactionsController < ApplicationController
 
       # Filter out likes for reactions that are not longer enabled,
       # which match up to a ReactionUser in historical data.
-      historical_likes =
+      historical_reaction_likes =
         likes
           .joins(
             "LEFT JOIN discourse_reactions_reaction_users ON discourse_reactions_reaction_users.user_id = post_actions.user_id AND discourse_reactions_reaction_users.post_id = post_actions.post_id",
@@ -185,7 +185,7 @@ class DiscourseReactions::CustomReactionsController < ApplicationController
             valid_reactions: DiscourseReactions::Reaction.valid_reactions.to_a,
           )
 
-      likes = likes.where.not(id: historical_likes.pluck(&:id))
+      likes = likes.where.not(id: historical_reaction_likes.select(&:id))
     end
 
     if likes.present?

--- a/app/controllers/discourse_reactions/custom_reactions_controller.rb
+++ b/app/controllers/discourse_reactions/custom_reactions_controller.rb
@@ -162,13 +162,30 @@ class DiscourseReactions::CustomReactionsController < ApplicationController
 
     if !reaction_value || reaction_value == DiscourseReactions::Reaction.main_reaction_id
       # We only want to get likes that don't have an associated ReactionUser
-      # record, which count as a like or will be double ups for main_reaction_id.
+      # record, which count as a like or there will be double ups for main_reaction_id.
       likes =
         post.post_actions.where(
           DiscourseReactions::PostActionExtension.filter_reaction_likes_sql,
           like: PostActionType.types[:like],
           valid_reactions: DiscourseReactions::Reaction.valid_reactions.to_a,
         )
+
+      # Filter out likes for reactions that are not longer enabled,
+      # which match up to a ReactionUser in historical data.
+      historical_likes =
+        likes
+          .joins(
+            "LEFT JOIN discourse_reactions_reaction_users ON discourse_reactions_reaction_users.user_id = post_actions.user_id AND discourse_reactions_reaction_users.post_id = post_actions.post_id",
+          )
+          .joins(
+            "LEFT JOIN discourse_reactions_reactions ON discourse_reactions_reactions.id = discourse_reactions_reaction_users.reaction_id",
+          )
+          .where(
+            "discourse_reactions_reactions.reaction_value NOT IN (:valid_reactions)",
+            valid_reactions: DiscourseReactions::Reaction.valid_reactions.to_a,
+          )
+
+      likes = likes.where.not(id: historical_likes.pluck(&:id))
     end
 
     if likes.present?

--- a/app/models/discourse_reactions/reaction.rb
+++ b/app/models/discourse_reactions/reaction.rb
@@ -20,7 +20,7 @@ module DiscourseReactions
     def self.valid_reactions
       Set[
         DiscourseReactions::Reaction.main_reaction_id,
-        *SiteSetting.discourse_reactions_enabled_reactions.split("|")
+        *SiteSetting.discourse_reactions_enabled_reactions.to_s.split("|")
       ]
     end
 
@@ -28,11 +28,14 @@ module DiscourseReactions
       SiteSetting.discourse_reactions_reaction_for_like.gsub("-", "")
     end
 
+    def self.reactions_excluded_from_like
+      SiteSetting.discourse_reactions_excluded_from_like.to_s.split("|")
+    end
+
     def self.reactions_counting_as_like
       Set[
         *(
-          valid_reactions.to_a -
-            SiteSetting.discourse_reactions_excluded_from_like.to_s.split("|") -
+          valid_reactions.to_a - reactions_excluded_from_like -
             [DiscourseReactions::Reaction.main_reaction_id]
         ).flatten
       ]

--- a/app/services/discourse_reactions/reaction_like_synchronizer.rb
+++ b/app/services/discourse_reactions/reaction_like_synchronizer.rb
@@ -7,7 +7,7 @@ module DiscourseReactions
     end
 
     def initialize
-      @excluded_from_like = SiteSetting.discourse_reactions_excluded_from_like.to_s.split("|")
+      @excluded_from_like = DiscourseReactions::Reaction.reactions_excluded_from_like
     end
 
     def sync!

--- a/app/services/discourse_reactions/reaction_manager.rb
+++ b/app/services/discourse_reactions/reaction_manager.rb
@@ -127,7 +127,7 @@ module DiscourseReactions
     end
 
     def reaction_excluded_from_like?
-      SiteSetting.discourse_reactions_excluded_from_like.to_s.split("|").include?(@reaction_value)
+      DiscourseReactions::Reaction.reactions_excluded_from_like.include?(@reaction_value)
     end
   end
 end

--- a/plugin.rb
+++ b/plugin.rb
@@ -93,7 +93,11 @@ after_initialize do
           count: reaction.reaction_users_count,
         }
 
-        if DiscourseReactions::Reaction.reactions_counting_as_like.include?(reaction.reaction_value)
+        # NOTE: It does not matter if the reaction is currently an enabled one,
+        # we need to handle historical data here too so we don't see double-ups in the UI.
+        if !DiscourseReactions::Reaction.reactions_excluded_from_like.include?(
+             reaction.reaction_value,
+           ) && reaction.reaction_value != DiscourseReactions::Reaction.main_reaction_id
           reaction_users_counting_as_like << reaction.reaction_users
         end
       end

--- a/plugin.rb
+++ b/plugin.rb
@@ -114,16 +114,17 @@ after_initialize do
           # Get rid of any PostAction records that match up to a ReactionUser
           # that is NOT main_reaction_id and is NOT excluded, otherwise we double
           # up on the count/reaction shown in the UI.
-          reaction_users_counting_as_like
-            .find { |ru| ru.user_id == post_action.user_id }
-            .present? ||
-            # Also get rid of any PostAction records that match up to a ReactionUser
-            # that is now the main_reaction_id and has historical data.
-            (
-              post_action.reaction_user.present? &&
-                post_action.reaction_user.reaction.reaction_value ==
-                  DiscourseReactions::Reaction.main_reaction_id
-            )
+          is_reaction_like_duplicate =
+            reaction_users_counting_as_like.any? { |ru| ru.user_id == post_action.user_id }
+
+          # Also get rid of any PostAction records that match up to a ReactionUser
+          # that is now the main_reaction_id and has historical data.
+          is_previously_enabled_reaction =
+            post_action.reaction_user.present? &&
+              post_action.reaction_user.reaction.reaction_value ==
+                DiscourseReactions::Reaction.main_reaction_id
+
+          is_reaction_like_duplicate || is_previously_enabled_reaction
         end
 
     # Likes will only be blank if there are only reactions where the reaction is in

--- a/plugin.rb
+++ b/plugin.rb
@@ -114,7 +114,16 @@ after_initialize do
           # Get rid of any PostAction records that match up to a ReactionUser
           # that is NOT main_reaction_id and is NOT excluded, otherwise we double
           # up on the count/reaction shown in the UI.
-          reaction_users_counting_as_like.find { |ru| ru.user_id == post_action.user_id }.present?
+          reaction_users_counting_as_like
+            .find { |ru| ru.user_id == post_action.user_id }
+            .present? ||
+            # Also get rid of any PostAction records that match up to a ReactionUser
+            # that is now the main_reaction_id and has historical data.
+            (
+              post_action.reaction_user.present? &&
+                post_action.reaction_user.reaction.reaction_value ==
+                  DiscourseReactions::Reaction.main_reaction_id
+            )
         end
 
     # Likes will only be blank if there are only reactions where the reaction is in
@@ -122,7 +131,8 @@ after_initialize do
     return reactions.sort_by { |reaction| [-reaction[:count].to_i, reaction[:id]] } if likes.blank?
 
     # Reactions using main_reaction_id only have a `PostAction` record,
-    # not any `ReactionUser` records.
+    # not any `ReactionUser` records, as long as the main_reaction_id was never
+    # changed -- if it was then we could have a ReactionUser as well.
     reaction_likes, reactions =
       reactions.partition { |r| r[:id] == DiscourseReactions::Reaction.main_reaction_id }
 

--- a/spec/serializers/topic_view_serializer_spec.rb
+++ b/spec/serializers/topic_view_serializer_spec.rb
@@ -43,7 +43,7 @@ describe TopicViewSerializer do
         %w[laughing heart open_mouth cry angry thumbsup thumbsdown].to_set,
       )
       expect(json[:post_stream][:posts][0][:reactions]).to eq(
-        [{ id: "heart", type: :emoji, count: 2 }, { id: "otter", type: :emoji, count: 2 }],
+        [{ id: "otter", type: :emoji, count: 2 }],
       )
 
       expect(json[:post_stream][:posts][0][:reaction_users_count]).to eq(2)


### PR DESCRIPTION
This commit fixes this scenario:

1. A user reacts to a post (+1), and their reaction also counts as a like
1. Another user sees the post and sees only +1
1. The admin changes SiteSetting.discourse_reactions_enabled_reactions
   to no longer enable the +1 reaction
1. The user now sees both +1 and a heart on the post

The fix makes it so the post still only shows a +1 even
though that is no longer an "enabled" reaction since it is
historical data.

It also fixes up some other discrepencies with like counts
and reaction counts based on changing settings after the fact,
like changing the `main_reaction_id` (which is definitely not advised).
