### PR TITLE
DEV: Turn on like sync for new sites and disable for existing

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -22,4 +22,4 @@ discourse_reactions:
     default: "-1"
     validator: "ReactionsExcludedFromLikeSiteSettingValidator"
   discourse_reactions_like_sync_enabled:
-    default: false
+    default: true

--- a/db/migrate/20240521032001_disable_reactions_like_sync_for_existing_sites.rb
+++ b/db/migrate/20240521032001_disable_reactions_like_sync_for_existing_sites.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class DisableReactionsLikeSyncForExistingSites < ActiveRecord::Migration[7.0]
+  def up
+    # 5 is bool data_type
+    execute <<~SQL if Migration::Helpers.existing_site?
+      INSERT INTO site_settings(name, data_type, value, created_at, updated_at)
+      VALUES('discourse_reactions_like_sync_enabled', 5, 'f', NOW(), NOW())
+      ON CONFLICT (name) DO NOTHING
+    SQL
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end


### PR DESCRIPTION
This commit changes `discourse_reactions_like_sync_enabled` to be
default true since we are rolling this out to all sites now.

Existing sites will have this set to false so we don't surprisingly
start doing this like sync in the background.
