### PR TITLE
PERF: static id for like post action type

### DIFF
--- a/app/controllers/discourse_reactions/custom_reactions_controller.rb
+++ b/app/controllers/discourse_reactions/custom_reactions_controller.rb
@@ -125,7 +125,7 @@ class DiscourseReactions::CustomReactionsController < ApplicationController
           .where(
             post_id: post_ids,
             deleted_at: nil,
-            post_action_type_id: PostActionType.types[:like],
+            post_action_type_id: PostActionType::LIKE_POST_ACTION_ID,
           )
           .joins(<<~SQL)
             LEFT JOIN discourse_reactions_reaction_users ON
@@ -166,7 +166,7 @@ class DiscourseReactions::CustomReactionsController < ApplicationController
       likes =
         post.post_actions.where(
           DiscourseReactions::PostActionExtension.filter_reaction_likes_sql,
-          like: PostActionType.types[:like],
+          like: PostActionType::LIKE_POST_ACTION_ID,
           valid_reactions: DiscourseReactions::Reaction.valid_reactions.to_a,
         )
 

--- a/app/models/discourse_reactions/reaction_user.rb
+++ b/app/models/discourse_reactions/reaction_user.rb
@@ -40,7 +40,7 @@ module DiscourseReactions
         PostAction.find_by(
           user_id: self.user_id,
           post_id: self.post_id,
-          post_action_type_id: PostActionType.types[:like],
+          post_action_type_id: PostActionType::LIKE_POST_ACTION_ID,
         )
     end
 

--- a/app/services/discourse_reactions/reaction_like_synchronizer.rb
+++ b/app/services/discourse_reactions/reaction_like_synchronizer.rb
@@ -90,7 +90,7 @@ module DiscourseReactions
 
       DB.query_single(
         sql_query,
-        pa_like: PostActionType.types[:like],
+        pa_like: PostActionType::LIKE_POST_ACTION_ID,
         excluded_from_like: @excluded_from_like,
       )
     end
@@ -111,7 +111,7 @@ module DiscourseReactions
 
       DB.query_single(
         sql_query,
-        pa_like: PostActionType.types[:like],
+        pa_like: PostActionType::LIKE_POST_ACTION_ID,
         excluded_from_like: @excluded_from_like,
       )
     end
@@ -228,7 +228,7 @@ module DiscourseReactions
 
       DB.query_single(
         sql_query,
-        like: PostActionType.types[:like],
+        like: PostActionType::LIKE_POST_ACTION_ID,
         excluded_from_like: @excluded_from_like,
         ua_like: UserAction::LIKE,
         ua_was_liked: UserAction::WAS_LIKED,

--- a/app/services/discourse_reactions/reaction_manager.rb
+++ b/app/services/discourse_reactions/reaction_manager.rb
@@ -9,7 +9,7 @@ module DiscourseReactions
       @user = user
       @post = post
       @like =
-        @post.post_actions.find_by(user: @user, post_action_type_id: PostActionType.types[:like])
+        @post.post_actions.find_by(user: @user, post_action_type_id: PostActionType::LIKE_POST_ACTION_ID)
       @previous_reaction_value =
         if @like && !reaction_user
           DiscourseReactions::Reaction.main_reaction_id
@@ -97,7 +97,7 @@ module DiscourseReactions
     end
 
     def remove_shadow_like
-      PostActionDestroyer.new(@user, @post, PostActionType.types[:like]).perform
+      PostActionDestroyer.new(@user, @post, PostActionType::LIKE_POST_ACTION_ID).perform
       delete_like_reaction
       remove_reaction_notification
     end

--- a/app/services/discourse_reactions/reaction_manager.rb
+++ b/app/services/discourse_reactions/reaction_manager.rb
@@ -9,7 +9,10 @@ module DiscourseReactions
       @user = user
       @post = post
       @like =
-        @post.post_actions.find_by(user: @user, post_action_type_id: PostActionType::LIKE_POST_ACTION_ID)
+        @post.post_actions.find_by(
+          user: @user,
+          post_action_type_id: PostActionType::LIKE_POST_ACTION_ID,
+        )
       @previous_reaction_value =
         if @like && !reaction_user
           DiscourseReactions::Reaction.main_reaction_id

--- a/lib/discourse_reactions/migration_report.rb
+++ b/lib/discourse_reactions/migration_report.rb
@@ -8,7 +8,8 @@ module DiscourseReactions
         topic_user_liked: TopicUser.where(liked: true).count,
         user_actions_liked: UserAction.where(action_type: UserAction::LIKE).count,
         user_actions_was_liked: UserAction.where(action_type: UserAction::WAS_LIKED).count,
-        post_action_likes: PostAction.where(post_action_type_id: PostActionType::LIKE_POST_ACTION_ID).count,
+        post_action_likes:
+          PostAction.where(post_action_type_id: PostActionType::LIKE_POST_ACTION_ID).count,
         post_like_count_total: Post.sum(:like_count),
         topic_like_count_total: Topic.sum(:like_count),
         user_stat_likes_given_total: UserStat.sum(:likes_given),
@@ -58,12 +59,12 @@ module DiscourseReactions
       <<~REPORT
       Reaction migration report:
       ------------------------------------------------------------
-      
+
       main_reaction_id:                       #{DiscourseReactions::Reaction.main_reaction_id}
       discourse_reactions_like_sync_enabled:  #{SiteSetting.discourse_reactions_like_sync_enabled}
       discourse_reactions_enabled_reactions:  #{SiteSetting.discourse_reactions_enabled_reactions}
       discourse_reactions_excluded_from_like: #{SiteSetting.discourse_reactions_excluded_from_like}
-      
+
       PostAction likes:        #{report_data[:post_action_likes]}#{report_data_diff_indicators[:post_action_likes]}
       UserActions.liked:       #{report_data[:user_actions_liked]}#{report_data_diff_indicators[:user_actions_liked]}
       UserActions.was_liked:   #{report_data[:user_actions_was_liked]}#{report_data_diff_indicators[:user_actions_was_liked]}

--- a/lib/discourse_reactions/migration_report.rb
+++ b/lib/discourse_reactions/migration_report.rb
@@ -8,7 +8,7 @@ module DiscourseReactions
         topic_user_liked: TopicUser.where(liked: true).count,
         user_actions_liked: UserAction.where(action_type: UserAction::LIKE).count,
         user_actions_was_liked: UserAction.where(action_type: UserAction::WAS_LIKED).count,
-        post_action_likes: PostAction.where(post_action_type_id: PostActionType.types[:like]).count,
+        post_action_likes: PostAction.where(post_action_type_id: PostActionType::LIKE_POST_ACTION_ID).count,
         post_like_count_total: Post.sum(:like_count),
         topic_like_count_total: Topic.sum(:like_count),
         user_stat_likes_given_total: UserStat.sum(:likes_given),

--- a/lib/discourse_reactions/topic_view_serializer_extension.rb
+++ b/lib/discourse_reactions/topic_view_serializer_extension.rb
@@ -9,7 +9,7 @@ module DiscourseReactions::TopicViewSerializerExtension
       )
       .where(post_id: post_ids)
       .where("post_actions.deleted_at IS NULL")
-      .where(post_action_type_id: PostActionType.types[:like])
+      .where(post_action_type_id: PostActionType::LIKE_POST_ACTION_ID)
       .where(
         "post_actions.post_id IN (#{DiscourseReactions::PostActionExtension.post_action_with_reaction_user_sql})",
         valid_reactions: DiscourseReactions::Reaction.reactions_counting_as_like,
@@ -42,7 +42,7 @@ module DiscourseReactions::TopicViewSerializerExtension
   def self.prepended(base)
     def base.posts_reaction_users_count(post_ids)
       posts_reaction_users_count_query =
-        DB.query(<<~SQL, post_ids: Array.wrap(post_ids), like_id: PostActionType.types[:like])
+        DB.query(<<~SQL, post_ids: Array.wrap(post_ids), like_id: PostActionType::LIKE_POST_ACTION_ID)
         SELECT union_subquery.post_id, COUNT(DISTINCT(union_subquery.user_id)) FROM (
             SELECT user_id, post_id FROM post_actions
               WHERE post_id IN (:post_ids)

--- a/lib/discourse_reactions/topic_view_serializer_extension.rb
+++ b/lib/discourse_reactions/topic_view_serializer_extension.rb
@@ -42,7 +42,8 @@ module DiscourseReactions::TopicViewSerializerExtension
   def self.prepended(base)
     def base.posts_reaction_users_count(post_ids)
       posts_reaction_users_count_query =
-        DB.query(<<~SQL, post_ids: Array.wrap(post_ids), like_id: PostActionType::LIKE_POST_ACTION_ID)
+        DB.query(
+          <<~SQL,
         SELECT union_subquery.post_id, COUNT(DISTINCT(union_subquery.user_id)) FROM (
             SELECT user_id, post_id FROM post_actions
               WHERE post_id IN (:post_ids)
@@ -55,6 +56,9 @@ module DiscourseReactions::TopicViewSerializerExtension
               WHERE posts.id IN (:post_ids)
         ) AS union_subquery WHERE union_subquery.post_ID IS NOT NULL GROUP BY union_subquery.post_id
       SQL
+          post_ids: Array.wrap(post_ids),
+          like_id: PostActionType::LIKE_POST_ACTION_ID,
+        )
 
       posts_reaction_users_count_query.each_with_object({}) do |row, hash|
         hash[row.post_id] = row.count

--- a/plugin.rb
+++ b/plugin.rb
@@ -165,8 +165,8 @@ after_initialize do
     # will count as the main_reaction_id.
     like =
       object.post_actions.find do |post_action|
-        post_action.post_action_type_id == PostActionType.types[:like] && !post_action.trashed? &&
-          post_action.user_id == scope.user.id
+        post_action.post_action_type_id == PostActionType::LIKE_POST_ACTION_ID &&
+          !post_action.trashed? && post_action.user_id == scope.user.id
       end
 
     return nil if like.blank?
@@ -188,7 +188,7 @@ after_initialize do
 
     like_post_action =
       object.post_actions.find do |post_action|
-        post_action.post_action_type_id == PostActionType.types[:like] &&
+        post_action.post_action_type_id == PostActionType::LIKE_POST_ACTION_ID &&
           post_action.user_id == scope.user.id && !post_action.trashed?
       end
 
@@ -260,7 +260,7 @@ after_initialize do
     SQL
         start_date: report.start_date.to_date,
         end_date: report.end_date.to_date,
-        like: PostActionType.types[:like],
+        like: PostActionType::LIKE_POST_ACTION_ID,
         valid_reactions: DiscourseReactions::Reaction.valid_reactions.to_a,
       )
 

--- a/spec/fabricators/reaction_user_fabricator.rb
+++ b/spec/fabricators/reaction_user_fabricator.rb
@@ -14,7 +14,7 @@ Fabricator(:reaction_user, class_name: "DiscourseReactions::ReactionUser") do
         :post_action,
         user: reaction_user.user,
         post: reaction_user.post,
-        post_action_type_id: PostActionType.types[:like],
+        post_action_type_id: PostActionType::LIKE_POST_ACTION_ID,
         created_at: reaction_user.created_at,
       )
     end

--- a/spec/reports/reactions_spec.rb
+++ b/spec/reports/reactions_spec.rb
@@ -18,7 +18,7 @@ describe Report do
       :post_action,
       post: post_1,
       user: user_1,
-      post_action_type_id: PostActionType.types[:like],
+      post_action_type_id: PostActionType::LIKE_POST_ACTION_ID,
       created_at: 1.day.ago,
     )
     Fabricate(
@@ -32,7 +32,7 @@ describe Report do
       :post_action,
       post: post_2,
       user: user_2,
-      post_action_type_id: PostActionType.types[:like],
+      post_action_type_id: PostActionType::LIKE_POST_ACTION_ID,
       created_at: 1.day.ago,
     )
 
@@ -73,14 +73,14 @@ describe Report do
       :post_action,
       post: post_1,
       user: user_1,
-      post_action_type_id: PostActionType.types[:like],
+      post_action_type_id: PostActionType::LIKE_POST_ACTION_ID,
       created_at: 1.day.ago,
     )
     Fabricate(
       :post_action,
       post: post_2,
       user: user_2,
-      post_action_type_id: PostActionType.types[:like],
+      post_action_type_id: PostActionType::LIKE_POST_ACTION_ID,
       created_at: 1.day.ago,
       deleted_at: 1.day.ago,
     )

--- a/spec/requests/custom_reactions_controller_spec.rb
+++ b/spec/requests/custom_reactions_controller_spec.rb
@@ -28,7 +28,7 @@ describe DiscourseReactions::CustomReactionsController do
       :post_action,
       post: post_2,
       user: user_5,
-      post_action_type_id: PostActionType.types[:like],
+      post_action_type_id: PostActionType::LIKE_POST_ACTION_ID,
     )
   end
   fab!(:reaction_user_1) do
@@ -411,7 +411,7 @@ describe DiscourseReactions::CustomReactionsController do
           :post_action,
           post: post_1,
           user: user_5,
-          post_action_type_id: PostActionType.types[:like],
+          post_action_type_id: PostActionType::LIKE_POST_ACTION_ID,
         )
       sign_in(user_1)
 
@@ -438,7 +438,7 @@ describe DiscourseReactions::CustomReactionsController do
           :post_action,
           post: post_1,
           user: user_4,
-          post_action_type_id: PostActionType.types[:like],
+          post_action_type_id: PostActionType::LIKE_POST_ACTION_ID,
         )
       sign_in(user_1)
 
@@ -537,7 +537,7 @@ describe DiscourseReactions::CustomReactionsController do
           :post_action,
           post: post_for_enabled_reactions,
           user: user_4,
-          post_action_type_id: PostActionType.types[:like],
+          post_action_type_id: PostActionType::LIKE_POST_ACTION_ID,
         )
 
       get "/discourse-reactions/posts/#{post_for_enabled_reactions.id}/reactions-users.json"
@@ -575,7 +575,7 @@ describe DiscourseReactions::CustomReactionsController do
         put "/discourse-reactions/posts/#{post_1.id}/custom-reactions/heart/toggle.json"
       end.to change { Notification.count }.by(1).and change { PostAction.count }.by(1)
 
-      expect(PostAction.last.post_action_type_id).to eq(PostActionType.types[:like])
+      expect(PostAction.last.post_action_type_id).to eq(PostActionType::LIKE_POST_ACTION_ID)
 
       expect do
         put "/discourse-reactions/posts/#{post_1.id}/custom-reactions/heart/toggle.json"

--- a/spec/requests/post_action_users_controller_spec.rb
+++ b/spec/requests/post_action_users_controller_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe PostActionUsersController do
       get "/post_action_users.json",
           params: {
             id: post.id,
-            post_action_type_id: PostActionType.types[:like],
+            post_action_type_id: PostActionType::LIKE_POST_ACTION_ID,
           }
       expect(response.status).to eq(200)
       expect(response.parsed_body["post_action_users"].map { |u| u["id"] }).to match_array(

--- a/spec/serializers/post_serializer_spec.rb
+++ b/spec/serializers/post_serializer_spec.rb
@@ -32,7 +32,7 @@ describe PostSerializer do
       :post_action,
       post: post_1,
       user: user_4,
-      post_action_type_id: PostActionType.types[:like],
+      post_action_type_id: PostActionType::LIKE_POST_ACTION_ID,
     )
   end
 

--- a/spec/serializers/topic_view_serializer_spec.rb
+++ b/spec/serializers/topic_view_serializer_spec.rb
@@ -20,7 +20,7 @@ describe TopicViewSerializer do
         :post_action,
         post: post_1,
         user: user_1,
-        post_action_type_id: PostActionType.types[:like],
+        post_action_type_id: PostActionType::LIKE_POST_ACTION_ID,
       )
     end
     fab!(:like_2) do
@@ -28,7 +28,7 @@ describe TopicViewSerializer do
         :post_action,
         post: post_1,
         user: user_2,
-        post_action_type_id: PostActionType.types[:like],
+        post_action_type_id: PostActionType::LIKE_POST_ACTION_ID,
       )
     end
     let(:topic) { post_1.topic }
@@ -94,7 +94,7 @@ describe TopicViewSerializer do
         :post_action,
         post: post_1,
         user: user_1,
-        post_action_type_id: PostActionType.types[:like],
+        post_action_type_id: PostActionType::LIKE_POST_ACTION_ID,
       )
     end
     let(:topic) { post_1.topic }

--- a/spec/services/reaction_like_synchronizer_spec.rb
+++ b/spec/services/reaction_like_synchronizer_spec.rb
@@ -112,7 +112,7 @@ RSpec.describe DiscourseReactions::ReactionLikeSynchronizer do
           :post_action,
           post: reaction_user_2.post,
           user: reaction_user_2.user,
-          post_action_type_id: PostActionType.types[:like],
+          post_action_type_id: PostActionType::LIKE_POST_ACTION_ID,
         )
       trashed_post_action.trash!(Fabricate(:user))
       SiteSetting.discourse_reactions_excluded_from_like = "-1" # clap removed

--- a/spec/services/reaction_manager_spec.rb
+++ b/spec/services/reaction_manager_spec.rb
@@ -86,7 +86,7 @@ RSpec.describe DiscourseReactions::ReactionManager do
               PostAction.find_by(
                 post: post,
                 user: user,
-                post_action_type_id: PostActionType.types[:like],
+                post_action_type_id: PostActionType::LIKE_POST_ACTION_ID,
               ),
             ).to be_nil
           end
@@ -104,7 +104,7 @@ RSpec.describe DiscourseReactions::ReactionManager do
               PostAction.find_by(
                 post: post,
                 user: user,
-                post_action_type_id: PostActionType.types[:like],
+                post_action_type_id: PostActionType::LIKE_POST_ACTION_ID,
               ),
             ).to be_present
           end
@@ -158,7 +158,7 @@ RSpec.describe DiscourseReactions::ReactionManager do
             :post_action,
             post: post,
             user: user,
-            post_action_type_id: PostActionType.types[:like],
+            post_action_type_id: PostActionType::LIKE_POST_ACTION_ID,
           )
         end
 


### PR DESCRIPTION
Before flags were in the database, PostActionType.types were stored in memory and getting `PostActionType.types[:like]` was a very cheap operation.

Now, PostActionType is cached in Redis and we should try to avoid sending too many requests, especially that id for `like` is always `2`.