### PR TITLE
FIX: Undefined method for `nil` error in `PostSerializer#reactions`

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -112,7 +112,9 @@ after_initialize do
 
         # Also get rid of any PostAction records that match up to a ReactionUser
         # that is now the main_reaction_id and has historical data.
-        object.post_actions_with_reaction_users[post_action.id]
+        object
+          .post_actions_with_reaction_users
+          &.dig(post_action.id)
           &.reaction_user
           &.reaction
           &.reaction_value == DiscourseReactions::Reaction.main_reaction_id


### PR DESCRIPTION
Follow-up to 708722ad132bab9a38f610dbed32639eed105343

Note that this is considered a hotfix so there is no tests. Expect a
proper fix to follow shortly after.
