### PR TITLE
DEV: Fix mismatched column types

### DIFF
--- a/db/migrate/20241025133536_alter_reaction_ids_to_bigint.rb
+++ b/db/migrate/20241025133536_alter_reaction_ids_to_bigint.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class AlterReactionIdsToBigint < ActiveRecord::Migration[7.1]
+  def up
+    change_column :discourse_reactions_reaction_users, :reaction_id, :bigint
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/spec/plugin_helper.rb
+++ b/spec/plugin_helper.rb
@@ -1,9 +1,0 @@
-# frozen_string_literal: true
-
-RSpec.configure do |config|
-  config.before(:suite) do
-    if defined?(migrate_column_to_bigint)
-      migrate_column_to_bigint(DiscourseReactions::ReactionUser, :reaction_id)
-    end
-  end
-end


### PR DESCRIPTION
The primary key is usually a bigint column, but the foreign key columns are usually of integer type. This can lead to issues when joining these columns due to mismatched types and different value ranges.

This was using a temporary plugin / test API to make tests pass, but it is safe to alter these tables because they usually have less than 1M rows and migration is going to be fast.