### PR TITLE
UI: Fix small alignment issue when using the Glimmer Post Menu on mobile mode

### DIFF
--- a/assets/javascripts/discourse/components/discourse-reactions-actions-button.gjs
+++ b/assets/javascripts/discourse/components/discourse-reactions-actions-button.gjs
@@ -4,6 +4,7 @@ import MountWidget from "discourse/components/mount-widget";
 const ReactionsActionButton = <template>
   {{! template-lint-disable no-capital-arguments }}
   <MountWidget
+    class="discourse-reactions-actions-button-shim"
     @widget="discourse-reactions-actions"
     @args={{hash post=@post}}
   />

--- a/assets/stylesheets/mobile/discourse-reactions.scss
+++ b/assets/stylesheets/mobile/discourse-reactions.scss
@@ -7,4 +7,10 @@
   .discourse-reactions-counter {
     margin: 0;
   }
+
+  // Fix for the alignment of the reactions summary button in the mobile view when using the Glimmer Post Menu
+  // This won't ber necessary once the reactions plugin is converted from widgets to Glimmer components
+  .discourse-reactions-actions-button-shim {
+    display: inline-flex;
+  }
 }


### PR DESCRIPTION
- before:

![image](https://github.com/user-attachments/assets/610fabeb-1ee0-4d44-96f9-4fab87c28d07)

- after:

![image](https://github.com/user-attachments/assets/39e3568b-487b-4d7c-9d1f-7641ebeb1c6e)

