### PR TITLE
DEV: pause reaction menu spinner when it's not visible

### DIFF
--- a/assets/stylesheets/common/discourse-reactions.scss
+++ b/assets/stylesheets/common/discourse-reactions.scss
@@ -42,6 +42,9 @@ html.discourse-reactions-no-select {
         .user-list {
           visibility: visible;
           opacity: 0.9;
+          .spinner {
+            animation-play-state: running;
+          }
         }
       }
     }
@@ -55,6 +58,10 @@ html.discourse-reactions-no-select {
       padding: 0.5em 0;
       min-width: 120px;
       min-height: 80px;
+
+      .spinner {
+        animation-play-state: paused;
+      }
 
       .container {
         margin-top: 0.5em;


### PR DESCRIPTION
Because the "who reacted" menu is hidden by `visibility: hidden` until the content loads, and the spinner spins until there's content available, the animation continues infinitely in the background on every post when using the glimmer post menu.  

This could have some minor performance impacts, so pausing it until it's visible seems like a safe thing to do. 

![image](https://github.com/user-attachments/assets/fd34950d-dd3a-4ea8-8f24-2361831dbfa7)
