### PR TITLE
DEV: Update deprecated Font Awesome icon names

### DIFF
--- a/.discourse-compatibility
+++ b/.discourse-compatibility
@@ -1,3 +1,4 @@
+< 3.4.0.beta2-dev: 101305c687cb8f3dc3aadc0e56fe5368393b0f9d
 < 3.4.0.beta1-dev: c4cde3bb12841733d1f2ac4df1bb099aae15cece
 < 3.3.0.beta1-dev: 354695cf5fce2bf516c9be451fe4bb56e487b95a
 < 3.2.0.beta2-dev: 14e269fb4161dc125aed516d1028c4e8f7960796

--- a/assets/javascripts/discourse/templates/connectors/user-activity-bottom/discourse-reactions-user-activity-reactions.hbs
+++ b/assets/javascripts/discourse/templates/connectors/user-activity-bottom/discourse-reactions-user-activity-reactions.hbs
@@ -1,6 +1,6 @@
 {{#if this.siteSettings.discourse_reactions_enabled}}
   <LinkTo @route="userActivity.reactions">
-    {{d-icon "far-smile"}}
+    {{d-icon "far-face-smile"}}
     <span>{{i18n "discourse_reactions.reactions_title"}}</span>
   </LinkTo>
 {{/if}}

--- a/assets/javascripts/discourse/templates/connectors/user-notifications-bottom/discourse-reactions-user-notification-reactions.hbs
+++ b/assets/javascripts/discourse/templates/connectors/user-notifications-bottom/discourse-reactions-user-notification-reactions.hbs
@@ -1,6 +1,6 @@
 {{#if this.siteSettings.discourse_reactions_enabled}}
   <LinkTo @route="userNotifications.reactionsReceived">
-    {{d-icon "far-smile"}}
+    {{d-icon "far-face-smile"}}
     <span>{{i18n "discourse_reactions.reactions_title"}}</span>
   </LinkTo>
 {{/if}}

--- a/plugin.rb
+++ b/plugin.rb
@@ -13,8 +13,8 @@ register_asset "stylesheets/common/discourse-reactions.scss"
 register_asset "stylesheets/desktop/discourse-reactions.scss", :desktop
 register_asset "stylesheets/mobile/discourse-reactions.scss", :mobile
 
-register_svg_icon "fas fa-star"
-register_svg_icon "far fa-star"
+register_svg_icon "star"
+register_svg_icon "far-star"
 
 require_relative "lib/reaction_for_like_site_setting_enum.rb"
 require_relative "lib/reactions_excluded_from_like_site_setting_validator.rb"


### PR DESCRIPTION
This PR updates deprecated Font Awesome icon names. For more detail, refer to the announcement at https://meta.discourse.org/t/-/325349.