### PR TITLE
DEV: Update more deprecated Font Awesome icon names

### DIFF
--- a/assets/javascripts/discourse/initializers/discourse-reactions.gjs
+++ b/assets/javascripts/discourse/initializers/discourse-reactions.gjs
@@ -11,7 +11,7 @@ import ReactionsActionSummary from "../components/discourse-reactions-actions-su
 
 const PLUGIN_ID = "discourse-reactions";
 
-replaceIcon("notification.reaction", "bell");
+["notification.reaction", "bell"]
 
 function initializeDiscourseReactions(api) {
   customizePostMenu(api);
@@ -94,7 +94,7 @@ function initializeDiscourseReactions(api) {
     { ignoreMissing: true }
   );
 
-  api.replaceIcon("notification.reaction", "discourse-emojis");
+  api.["notification.reaction", "discourse-emojis"]
 
   if (api.registerNotificationTypeRenderer) {
     api.registerNotificationTypeRenderer("reaction", (NotificationTypeBase) => {

--- a/assets/javascripts/discourse/templates/connectors/user-activity-bottom/discourse-reactions-user-activity-reactions.hbs
+++ b/assets/javascripts/discourse/templates/connectors/user-activity-bottom/discourse-reactions-user-activity-reactions.hbs
@@ -1,6 +1,6 @@
 {{#if this.siteSettings.discourse_reactions_enabled}}
   <LinkTo @route="userActivity.reactions">
-    {{d-icon "far-face-smile"}}
+    ["far-face-smile"]
     <span>{{i18n "discourse_reactions.reactions_title"}}</span>
   </LinkTo>
 {{/if}}

--- a/assets/javascripts/discourse/templates/connectors/user-notifications-bottom/discourse-reactions-user-notification-reactions.hbs
+++ b/assets/javascripts/discourse/templates/connectors/user-notifications-bottom/discourse-reactions-user-notification-reactions.hbs
@@ -1,6 +1,6 @@
 {{#if this.siteSettings.discourse_reactions_enabled}}
   <LinkTo @route="userNotifications.reactionsReceived">
-    {{d-icon "far-face-smile"}}
+    ["far-face-smile"]
     <span>{{i18n "discourse_reactions.reactions_title"}}</span>
   </LinkTo>
 {{/if}}

--- a/plugin.rb
+++ b/plugin.rb
@@ -13,8 +13,8 @@ register_asset "stylesheets/common/discourse-reactions.scss"
 register_asset "stylesheets/desktop/discourse-reactions.scss", :desktop
 register_asset "stylesheets/mobile/discourse-reactions.scss", :mobile
 
-register_svg_icon "star"
-register_svg_icon "far-star"
+["star"]
+["far-star"]
 
 require_relative "lib/reaction_for_like_site_setting_enum.rb"
 require_relative "lib/reactions_excluded_from_like_site_setting_validator.rb"


### PR DESCRIPTION
This PR updates more deprecated Font Awesome icon names. For more detail, refer to the announcement at https://meta.discourse.org/t/-/325349.