### PR TITLE
DEV: FA6 updates for icon setting description and badge fixture

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -1,6 +1,6 @@
 en:
   site_settings:
-    discourse_reactions_like_icon: "Defines the icon used for the main reaction button. This should be a <a href='https://fontawesome.com/v5/search?o=r&m=free' target='_blank'>Font Awesome</a> icon name, not an emoji name."
+    discourse_reactions_like_icon: "Defines the icon used for the main reaction button. This should be a <a href='https://fontawesome.com/v6/search?o=r&m=free' target='_blank'>Font Awesome</a> icon name, not an emoji name."
     discourse_reactions_reaction_for_like: "Defines the reaction associated to the Like action. Historical Like records will not be changed if this setting changes, it is <strong>strongly recommended</strong> that this setting is never changed."
     discourse_reactions_enabled: "Enable the discourse-reactions plugin."
     discourse_reactions_enabled_reactions: "Defines a list of enabled reactions, any emoji is allowed here."

--- a/db/fixtures/001_badges.rb
+++ b/db/fixtures/001_badges.rb
@@ -15,7 +15,7 @@ SQL
 
 Badge.seed(:name) do |b|
   b.name = "First Reaction"
-  b.default_icon = "smile"
+  b.default_icon = "face-smile"
   b.badge_type_id = BadgeType::Bronze
   b.multiple_grant = false
   b.target_posts = true


### PR DESCRIPTION
Core badges migrations were already done in https://github.com/discourse/discourse/pull/29958.

For more detail on the FA6 upgrade, refer to the announcement at https://meta.discourse.org/t/-/325349.