### PR TITLE
DEV: migrate smile to face-smile in badge icons

### DIFF
--- a/db/migrate/20250205104150_remap_deprecated_icon_names_for_badge_fixtures.rb
+++ b/db/migrate/20250205104150_remap_deprecated_icon_names_for_badge_fixtures.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+class RemapDeprecatedIconNamesForBadgeFixtures < ActiveRecord::Migration[7.2]
+  def up
+    execute <<~SQL
+      WITH remaps AS (
+        SELECT 'smile' AS from_icon, 'face-smile' AS to_icon
+      )
+      UPDATE badges
+      SET icon = remaps.to_icon
+      FROM remaps
+      WHERE icon = remaps.from_icon;
+    SQL
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end


### PR DESCRIPTION
This ensures the change to update the deprecated icon name `smile` in the badge seed fixture is also applied to existing data in the DB.


