### PR TITLE
FIX: Add TopicViewPostsSerializerExtension to fix N1s

### DIFF
--- a/lib/discourse_reactions/posts_reaction_loader.rb
+++ b/lib/discourse_reactions/posts_reaction_loader.rb
@@ -6,16 +6,15 @@ module DiscourseReactions::PostsReactionLoader
       posts = object.posts.includes(:post_actions, reactions: { reaction_users: :user })
       post_ids = posts.map(&:id).uniq
       posts_reaction_users_count = TopicViewSerializer.posts_reaction_users_count(post_ids)
-      posts.each { |post| post.reaction_users_count = posts_reaction_users_count[post.id].to_i }
-
       post_actions_with_reaction_users =
         DiscourseReactions::TopicViewSerializerExtension.load_post_action_reaction_users_for_posts(
           post_ids,
         )
-
       posts.each do |post|
+        post.reaction_users_count = posts_reaction_users_count[post.id].to_i
         post.post_actions_with_reaction_users = post_actions_with_reaction_users[post.id] || {}
       end
+
       object.instance_variable_set(:@posts, posts)
     end
   end

--- a/lib/discourse_reactions/posts_reaction_loader.rb
+++ b/lib/discourse_reactions/posts_reaction_loader.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module DiscourseReactions::PostsReactionLoader
+  def posts_with_reactions
+    if SiteSetting.discourse_reactions_enabled
+      posts = object.posts.includes(:post_actions, reactions: { reaction_users: :user })
+      post_ids = posts.map(&:id).uniq
+      posts_reaction_users_count = TopicViewSerializer.posts_reaction_users_count(post_ids)
+      posts.each { |post| post.reaction_users_count = posts_reaction_users_count[post.id].to_i }
+
+      post_actions_with_reaction_users =
+        DiscourseReactions::TopicViewSerializerExtension.load_post_action_reaction_users_for_posts(
+          post_ids,
+        )
+
+      posts.each do |post|
+        post.post_actions_with_reaction_users = post_actions_with_reaction_users[post.id] || {}
+      end
+      object.instance_variable_set(:@posts, posts)
+    end
+  end
+end

--- a/lib/discourse_reactions/topic_view_posts_serializer_extension.rb
+++ b/lib/discourse_reactions/topic_view_posts_serializer_extension.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module DiscourseReactions::TopicViewPostsSerializerExtension
+  # See also DiscourseReactions::TopicViewSerializerExtension
+  def posts
+    if SiteSetting.discourse_reactions_enabled
+      posts = object.posts.includes(:post_actions, reactions: { reaction_users: :user })
+      post_ids = posts.map(&:id).uniq
+      posts_reaction_users_count = TopicViewSerializer.posts_reaction_users_count(post_ids)
+      posts.each { |post| post.reaction_users_count = posts_reaction_users_count[post.id].to_i }
+
+      post_actions_with_reaction_users =
+        DiscourseReactions::TopicViewSerializerExtension.load_post_action_reaction_users_for_posts(
+          post_ids,
+        )
+
+      posts.each do |post|
+        post.post_actions_with_reaction_users = post_actions_with_reaction_users[post.id] || {}
+      end
+      object.instance_variable_set(:@posts, posts)
+    end
+    super
+  end
+end

--- a/lib/discourse_reactions/topic_view_posts_serializer_extension.rb
+++ b/lib/discourse_reactions/topic_view_posts_serializer_extension.rb
@@ -1,24 +1,10 @@
 # frozen_string_literal: true
 
 module DiscourseReactions::TopicViewPostsSerializerExtension
-  # See also DiscourseReactions::TopicViewSerializerExtension
+  include DiscourseReactions::PostsReactionLoader
+
   def posts
-    if SiteSetting.discourse_reactions_enabled
-      posts = object.posts.includes(:post_actions, reactions: { reaction_users: :user })
-      post_ids = posts.map(&:id).uniq
-      posts_reaction_users_count = TopicViewSerializer.posts_reaction_users_count(post_ids)
-      posts.each { |post| post.reaction_users_count = posts_reaction_users_count[post.id].to_i }
-
-      post_actions_with_reaction_users =
-        DiscourseReactions::TopicViewSerializerExtension.load_post_action_reaction_users_for_posts(
-          post_ids,
-        )
-
-      posts.each do |post|
-        post.post_actions_with_reaction_users = post_actions_with_reaction_users[post.id] || {}
-      end
-      object.instance_variable_set(:@posts, posts)
-    end
+    posts_with_reactions
     super
   end
 end

--- a/lib/discourse_reactions/topic_view_serializer_extension.rb
+++ b/lib/discourse_reactions/topic_view_serializer_extension.rb
@@ -20,6 +20,7 @@ module DiscourseReactions::TopicViewSerializerExtension
       end
   end
 
+  # See also DiscourseReactions::TopicViewPostsSerializerExtension
   def posts
     if SiteSetting.discourse_reactions_enabled
       posts = object.posts.includes(:post_actions, reactions: { reaction_users: :user })

--- a/lib/discourse_reactions/topic_view_serializer_extension.rb
+++ b/lib/discourse_reactions/topic_view_serializer_extension.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 module DiscourseReactions::TopicViewSerializerExtension
+  include DiscourseReactions::PostsReactionLoader
+
   def self.load_post_action_reaction_users_for_posts(post_ids)
     PostAction
       .joins(
@@ -20,26 +22,8 @@ module DiscourseReactions::TopicViewSerializerExtension
       end
   end
 
-  # See also DiscourseReactions::TopicViewPostsSerializerExtension
   def posts
-    if SiteSetting.discourse_reactions_enabled
-      posts = object.posts.includes(:post_actions, reactions: { reaction_users: :user })
-      post_ids = posts.map(&:id).uniq
-
-      posts_reaction_users_count = TopicViewSerializer.posts_reaction_users_count(post_ids)
-      posts.each { |post| post.reaction_users_count = posts_reaction_users_count[post.id].to_i }
-
-      post_actions_with_reaction_users =
-        DiscourseReactions::TopicViewSerializerExtension.load_post_action_reaction_users_for_posts(
-          post_ids,
-        )
-
-      posts.each do |post|
-        post.post_actions_with_reaction_users = post_actions_with_reaction_users[post.id] || {}
-      end
-
-      object.instance_variable_set(:@posts, posts)
-    end
+    posts_with_reactions
     super
   end
 

--- a/plugin.rb
+++ b/plugin.rb
@@ -46,6 +46,7 @@ after_initialize do
     lib/discourse_reactions/post_extension.rb
     lib/discourse_reactions/post_action_extension.rb
     lib/discourse_reactions/topic_view_serializer_extension.rb
+    lib/discourse_reactions/topic_view_posts_serializer_extension.rb
     lib/discourse_reactions/migration_report.rb
     app/jobs/regular/discourse_reactions/like_synchronizer.rb
     app/jobs/scheduled/discourse_reactions/scheduled_like_synchronizer.rb
@@ -55,6 +56,7 @@ after_initialize do
     Post.prepend DiscourseReactions::PostExtension
     PostAction.prepend DiscourseReactions::PostActionExtension
     TopicViewSerializer.prepend DiscourseReactions::TopicViewSerializerExtension
+    TopicViewPostsSerializer.prepend DiscourseReactions::TopicViewPostsSerializerExtension
     PostAlerter.prepend DiscourseReactions::PostAlerterExtension
     Guardian.prepend DiscourseReactions::GuardianExtension
     Notification.singleton_class.prepend DiscourseReactions::NotificationExtension

--- a/plugin.rb
+++ b/plugin.rb
@@ -45,6 +45,7 @@ after_initialize do
     lib/discourse_reactions/post_alerter_extension.rb
     lib/discourse_reactions/post_extension.rb
     lib/discourse_reactions/post_action_extension.rb
+    lib/discourse_reactions/posts_reaction_loader.rb
     lib/discourse_reactions/topic_view_serializer_extension.rb
     lib/discourse_reactions/topic_view_posts_serializer_extension.rb
     lib/discourse_reactions/migration_report.rb


### PR DESCRIPTION
The following N1s occur when fetching posts in a topic
past the OP via the /t/:id/posts.json endpoint, which
passes in an array of post_ids:

```
SELECT "discourse_reactions_reactions".* FROM "discourse_reactions_reactions" WHERE "discourse_reactions_reactions"."post_id" = :id;
```

```
SELECT "post_actions".* FROM "post_actions" WHERE
"post_actions"."deleted_at" IS NULL AND "post_actions"."post_id" = :id;
```

```
SELECT union_subquery.post_id, COUNT(DISTINCT(union_subquery.user_id)) FROM (    SELECT user_id, post_id FROM post_actions      WHERE post_id IN (14755)        AND post_action_type_id = 2        AND deleted_at IS NULL  UNION ALL    SELECT discourse_reactions_reaction_users.user_id, posts.id from posts      LEFT JOIN discourse_reactions_reactions ON discourse_reactions_reactions.post_id = posts.id      LEFT JOIN discourse_reactions_reaction_users ON discourse_reactions_reaction_users.reaction_id = discourse_reactions_reactions.id      WHERE posts.id IN (14755)) AS union_subquery WHERE union_subquery.post_ID IS NOT NULL GROUP BY union_subquery.post_id;
```

This was happening because we hadn't added additional includes
and prefetching on the posts query for `TopicViewPostsSerializer`, like we were on
`TopicViewSerializerExtension`. This commit adds the same logic
to the `TopicViewPostsSerializer` via an extension to eliminate
the N1s.
