### PR TITLE
DEV: Adds checks for 'prioritize_full_name_in_ux'

### DIFF
--- a/app/services/discourse_reactions/reaction_notification.rb
+++ b/app/services/discourse_reactions/reaction_notification.rb
@@ -18,7 +18,7 @@ module DiscourseReactions
         return
       end
 
-      opts = { user_id: @user.id, display_username: @user.username }
+      opts = { user_id: @user.id, display_username: @user.username, display_name: @user.name }
 
       if @reaction.reaction_value == HEART_ICON_NAME
         opts[:custom_data] = { reaction_icon: @reaction.reaction_value }
@@ -52,7 +52,7 @@ module DiscourseReactions
         .joins(:users)
         .order("discourse_reactions_reactions.created_at DESC")
         .where("discourse_reactions_reactions.created_at > ?", 1.day.ago)
-        .pluck(:username, :reaction_value)
+        .pluck(:username, :name, :reaction_value)
     end
 
     def refresh_notification(read)
@@ -66,11 +66,13 @@ module DiscourseReactions
         count: remaining_data.length,
         username: remaining_data[0][0],
         display_username: remaining_data[0][0],
+        display_name: remaining_data[0][1],
       }
 
       data[:username2] = remaining_data[1][0] if remaining_data[1]
+      data[:name2] = remaining_data[1][1] if remaining_data[1]
 
-      if remaining_data.all? { |element| element[1] == HEART_ICON_NAME }
+      if remaining_data.all? { |element| element[2] == HEART_ICON_NAME }
         data[:reaction_icon] = HEART_ICON_NAME
       end
 

--- a/app/services/discourse_reactions/reaction_notification.rb
+++ b/app/services/discourse_reactions/reaction_notification.rb
@@ -70,7 +70,7 @@ module DiscourseReactions
       }
 
       data[:username2] = remaining_data[1][0] if remaining_data[1]
-      data[:name2] = remaining_data[1][1] if remaining_data[1] # something's not connecting correctly...
+      data[:name2] = remaining_data[1][1] if remaining_data[1]
 
       if remaining_data.all? { |element| element[2] == HEART_ICON_NAME }
         data[:reaction_icon] = HEART_ICON_NAME

--- a/app/services/discourse_reactions/reaction_notification.rb
+++ b/app/services/discourse_reactions/reaction_notification.rb
@@ -70,7 +70,7 @@ module DiscourseReactions
       }
 
       data[:username2] = remaining_data[1][0] if remaining_data[1]
-      data[:name2] = remaining_data[1][1] if remaining_data[1]
+      data[:name2] = remaining_data[1][1] if remaining_data[1] # something's not connecting correctly...
 
       if remaining_data.all? { |element| element[2] == HEART_ICON_NAME }
         data[:reaction_icon] = HEART_ICON_NAME

--- a/assets/javascripts/discourse/initializers/discourse-reactions.gjs
+++ b/assets/javascripts/discourse/initializers/discourse-reactions.gjs
@@ -132,7 +132,6 @@ function initializeDiscourseReactions(api) {
             ? this.notification.data.display_name || this.username
             : this.username;
 
-          // A single reaction works locally for me
           if (!count || count === 1 || !this.notification.data.username2) {
             return nameOrUsername;
           }

--- a/assets/javascripts/discourse/initializers/discourse-reactions.gjs
+++ b/assets/javascripts/discourse/initializers/discourse-reactions.gjs
@@ -135,6 +135,8 @@ function initializeDiscourseReactions(api) {
             return nameOrUsername;
           }
           if (count > 2) {
+            console.log("OVER TWO REACTIONS!!!!!!!!!");
+            console.log(nameOrUsername);
             return i18n("notifications.reaction_multiple_users", {
               username: nameOrUsername,
               count: count - 1,

--- a/assets/javascripts/discourse/initializers/discourse-reactions.gjs
+++ b/assets/javascripts/discourse/initializers/discourse-reactions.gjs
@@ -128,22 +128,43 @@ function initializeDiscourseReactions(api) {
 
         get label() {
           const count = this.notification.data.count;
+          const fullname = this.notification.data.original_name;
           const username = this.username;
 
+          // A single reaction works locally for me
           if (!count || count === 1 || !this.notification.data.username2) {
-            return username;
+            if (!this.siteSettings.prioritize_full_name_in_ux) {
+              return username;
+            } else {
+              return fullname || username;
+            }
           }
-
+          // the following two (react consolidation) are running into an issue
           if (count > 2) {
-            return i18n("notifications.reaction_multiple_users", {
-              username,
-              count: count - 1,
-            });
+            if (!this.siteSettings.prioritize_full_name_in_ux) {
+              return I18n.t("notifications.reaction_multiple_users", {
+                username,
+                count: count - 1,
+              });
+            } else {
+              return I18n.t("notifications.reaction_multiple_users", {
+                fullname,
+                count: count - 1,
+              });
+            }
           } else {
-            return i18n("notifications.reaction_2_users", {
-              username,
-              username2: formatUsername(this.notification.data.username2),
-            });
+            if (!this.siteSettings.prioritize_full_name_in_ux) {
+              console.log("HERE I AM");
+              return I18n.t("notifications.reaction_2_users", {
+                username,
+                username2: formatUsername(this.notification.data.username2),
+              });
+            } else {
+              return I18n.t("notifications.reaction_2_users", {
+                fullname,
+                fullname2: null, // can't get into this to figure out what this would be on 'this.notification.data.??'
+              });
+            }
           }
         }
 

--- a/assets/javascripts/discourse/initializers/discourse-reactions.gjs
+++ b/assets/javascripts/discourse/initializers/discourse-reactions.gjs
@@ -140,13 +140,12 @@ function initializeDiscourseReactions(api) {
               count: count - 1,
             });
           } else {
-            const name2OrUsername2 = this.siteSettings
-              .prioritize_full_name_in_ux
+            const nameOrUsername2 = this.siteSettings.prioritize_full_name_in_ux
               ? this.notification.data.name2
               : this.notification.data.username2;
             return i18n("notifications.reaction_2_users", {
               username: nameOrUsername,
-              username2: name2OrUsername2,
+              username2: nameOrUsername2,
             });
           }
         }

--- a/assets/javascripts/discourse/initializers/discourse-reactions.gjs
+++ b/assets/javascripts/discourse/initializers/discourse-reactions.gjs
@@ -129,10 +129,10 @@ function initializeDiscourseReactions(api) {
         get label() {
           const count = this.notification.data.count;
           const nameOrUsername = this.siteSettings.prioritize_full_name_in_ux
-            ? this.notification.data.display_name ||
-              this.username
+            ? this.notification.data.display_name || this.username
             : this.username;
 
+          // A single reaction works locally for me
           if (!count || count === 1 || !this.notification.data.username2) {
             return nameOrUsername;
           }
@@ -143,7 +143,8 @@ function initializeDiscourseReactions(api) {
             });
           } else {
             const nameOrUsername2 = this.siteSettings.prioritize_full_name_in_ux
-              ? this.notification.data.name2 || formatUsername(this.notification.data.username2)
+              ? this.notification.data.name2 ||
+                formatUsername(this.notification.data.username2)
               : formatUsername(this.notification.data.username2);
             return i18n("notifications.reaction_2_users", {
               username: nameOrUsername,

--- a/assets/javascripts/discourse/initializers/discourse-reactions.gjs
+++ b/assets/javascripts/discourse/initializers/discourse-reactions.gjs
@@ -147,20 +147,19 @@ function initializeDiscourseReactions(api) {
                 count: count - 1,
               });
             } else {
-              return I18n.t("notifications.reaction_multiple_users", {
+              return I18n.t("notifications.fullname.reaction_multiple_users", {
                 fullname,
                 count: count - 1,
               });
             }
           } else {
             if (!this.siteSettings.prioritize_full_name_in_ux) {
-              console.log("HERE I AM");
               return I18n.t("notifications.reaction_2_users", {
                 username,
                 username2: formatUsername(this.notification.data.username2),
               });
             } else {
-              return I18n.t("notifications.reaction_2_users", {
+              return I18n.t("notifications.fullname.reaction_2_users", {
                 fullname,
                 fullname2: null, // can't get into this to figure out what this would be on 'this.notification.data.??'
               });

--- a/assets/javascripts/discourse/initializers/discourse-reactions.gjs
+++ b/assets/javascripts/discourse/initializers/discourse-reactions.gjs
@@ -128,18 +128,16 @@ function initializeDiscourseReactions(api) {
 
         get label() {
           const count = this.notification.data.count;
-          const fullname = this.notification.data.original_name;
+          const fullName = this.notification.acting_user_name;
           const username = this.username;
 
-          // A single reaction works locally for me
           if (!count || count === 1 || !this.notification.data.username2) {
             if (!this.siteSettings.prioritize_full_name_in_ux) {
               return username;
             } else {
-              return fullname || username;
+              return fullName || username;
             }
           }
-          // the following two (react consolidation) are running into an issue
           if (count > 2) {
             if (!this.siteSettings.prioritize_full_name_in_ux) {
               return i18n("notifications.reaction_multiple_users", {
@@ -148,7 +146,7 @@ function initializeDiscourseReactions(api) {
               });
             } else {
               return i18n("notifications.fullname.reaction_multiple_users", {
-                fullname,
+                fullName,
                 count: count - 1,
               });
             }
@@ -160,8 +158,8 @@ function initializeDiscourseReactions(api) {
               });
             } else {
               return i18n("notifications.fullname.reaction_2_users", {
-                fullname,
-                fullname2: null, // can't get into this to figure out what this would be on 'this.notification.data.??'
+                fullName,
+                fullName2: this.notification.data, // this is not correct, but I'm not sure what the correct object value is after "data"
               });
             }
           }

--- a/assets/javascripts/discourse/initializers/discourse-reactions.gjs
+++ b/assets/javascripts/discourse/initializers/discourse-reactions.gjs
@@ -3,7 +3,6 @@ import { replaceIcon } from "discourse/lib/icon-library";
 import { withPluginApi } from "discourse/lib/plugin-api";
 import { emojiUrlFor } from "discourse/lib/text";
 import { userPath } from "discourse/lib/url";
-import { formatUsername } from "discourse/lib/utilities";
 import { i18n } from "discourse-i18n";
 import { resetCurrentReaction } from "discourse/plugins/discourse-reactions/discourse/widgets/discourse-reactions-actions";
 import ReactionsActionButton from "../components/discourse-reactions-actions-button";
@@ -128,40 +127,27 @@ function initializeDiscourseReactions(api) {
 
         get label() {
           const count = this.notification.data.count;
-          const fullName = this.notification.acting_user_name;
-          const username = this.username;
+          const nameOrUsername = this.siteSettings.prioritize_full_name_in_ux
+            ? this.notification.data.display_name
+            : this.notification.data.display_username;
 
           if (!count || count === 1 || !this.notification.data.username2) {
-            if (!this.siteSettings.prioritize_full_name_in_ux) {
-              return username;
-            } else {
-              return fullName || username;
-            }
+            return nameOrUsername;
           }
           if (count > 2) {
-            if (!this.siteSettings.prioritize_full_name_in_ux) {
-              return i18n("notifications.reaction_multiple_users", {
-                username,
-                count: count - 1,
-              });
-            } else {
-              return i18n("notifications.fullname.reaction_multiple_users", {
-                fullName,
-                count: count - 1,
-              });
-            }
+            return i18n("notifications.reaction_multiple_users", {
+              username: nameOrUsername,
+              count: count - 1,
+            });
           } else {
-            if (!this.siteSettings.prioritize_full_name_in_ux) {
-              return i18n("notifications.reaction_2_users", {
-                username,
-                username2: formatUsername(this.notification.data.username2),
-              });
-            } else {
-              return i18n("notifications.fullname.reaction_2_users", {
-                fullName,
-                fullName2: this.notification.data, // this is not correct, but I'm not sure what the correct object value is after "data"
-              });
-            }
+            const name2OrUsername2 = this.siteSettings
+              .prioritize_full_name_in_ux
+              ? this.notification.data.name2
+              : this.notification.data.username2;
+            return i18n("notifications.reaction_2_users", {
+              username: nameOrUsername,
+              username2: name2OrUsername2,
+            });
           }
         }
 

--- a/assets/javascripts/discourse/initializers/discourse-reactions.gjs
+++ b/assets/javascripts/discourse/initializers/discourse-reactions.gjs
@@ -143,7 +143,7 @@ function initializeDiscourseReactions(api) {
             });
           } else {
             const nameOrUsername2 = this.siteSettings.prioritize_full_name_in_ux
-              ? this.notification.data.name2 || this.notification.data.username2
+              ? this.notification.data.name2 || formatUsername(this.notification.data.username2)
               : formatUsername(this.notification.data.username2);
             return i18n("notifications.reaction_2_users", {
               username: nameOrUsername,

--- a/assets/javascripts/discourse/initializers/discourse-reactions.gjs
+++ b/assets/javascripts/discourse/initializers/discourse-reactions.gjs
@@ -3,6 +3,7 @@ import { replaceIcon } from "discourse/lib/icon-library";
 import { withPluginApi } from "discourse/lib/plugin-api";
 import { emojiUrlFor } from "discourse/lib/text";
 import { userPath } from "discourse/lib/url";
+import { formatUsername } from "discourse/lib/utilities";
 import { i18n } from "discourse-i18n";
 import { resetCurrentReaction } from "discourse/plugins/discourse-reactions/discourse/widgets/discourse-reactions-actions";
 import ReactionsActionButton from "../components/discourse-reactions-actions-button";
@@ -135,8 +136,6 @@ function initializeDiscourseReactions(api) {
             return nameOrUsername;
           }
           if (count > 2) {
-            console.log("OVER TWO REACTIONS!!!!!!!!!");
-            console.log(nameOrUsername);
             return i18n("notifications.reaction_multiple_users", {
               username: nameOrUsername,
               count: count - 1,

--- a/assets/javascripts/discourse/initializers/discourse-reactions.gjs
+++ b/assets/javascripts/discourse/initializers/discourse-reactions.gjs
@@ -142,24 +142,24 @@ function initializeDiscourseReactions(api) {
           // the following two (react consolidation) are running into an issue
           if (count > 2) {
             if (!this.siteSettings.prioritize_full_name_in_ux) {
-              return I18n.t("notifications.reaction_multiple_users", {
+              return i18n("notifications.reaction_multiple_users", {
                 username,
                 count: count - 1,
               });
             } else {
-              return I18n.t("notifications.fullname.reaction_multiple_users", {
+              return i18n("notifications.fullname.reaction_multiple_users", {
                 fullname,
                 count: count - 1,
               });
             }
           } else {
             if (!this.siteSettings.prioritize_full_name_in_ux) {
-              return I18n.t("notifications.reaction_2_users", {
+              return i18n("notifications.reaction_2_users", {
                 username,
                 username2: formatUsername(this.notification.data.username2),
               });
             } else {
-              return I18n.t("notifications.fullname.reaction_2_users", {
+              return i18n("notifications.fullname.reaction_2_users", {
                 fullname,
                 fullname2: null, // can't get into this to figure out what this would be on 'this.notification.data.??'
               });

--- a/assets/javascripts/discourse/initializers/discourse-reactions.gjs
+++ b/assets/javascripts/discourse/initializers/discourse-reactions.gjs
@@ -129,7 +129,8 @@ function initializeDiscourseReactions(api) {
         get label() {
           const count = this.notification.data.count;
           const nameOrUsername = this.siteSettings.prioritize_full_name_in_ux
-            ? this.notification.data.display_name
+            ? this.notification.data.display_name ||
+              this.notification.data.username
             : this.username;
 
           if (!count || count === 1 || !this.notification.data.username2) {
@@ -142,7 +143,7 @@ function initializeDiscourseReactions(api) {
             });
           } else {
             const nameOrUsername2 = this.siteSettings.prioritize_full_name_in_ux
-              ? this.notification.data.name2
+              ? this.notification.data.name2 || this.notification.data.username2
               : formatUsername(this.notification.data.username2);
             return i18n("notifications.reaction_2_users", {
               username: nameOrUsername,

--- a/assets/javascripts/discourse/initializers/discourse-reactions.gjs
+++ b/assets/javascripts/discourse/initializers/discourse-reactions.gjs
@@ -130,7 +130,7 @@ function initializeDiscourseReactions(api) {
           const count = this.notification.data.count;
           const nameOrUsername = this.siteSettings.prioritize_full_name_in_ux
             ? this.notification.data.display_name ||
-              this.notification.data.username
+              this.username
             : this.username;
 
           if (!count || count === 1 || !this.notification.data.username2) {

--- a/assets/javascripts/discourse/initializers/discourse-reactions.gjs
+++ b/assets/javascripts/discourse/initializers/discourse-reactions.gjs
@@ -3,6 +3,7 @@ import { replaceIcon } from "discourse/lib/icon-library";
 import { withPluginApi } from "discourse/lib/plugin-api";
 import { emojiUrlFor } from "discourse/lib/text";
 import { userPath } from "discourse/lib/url";
+import { formatUsername } from "discourse/lib/utilities";
 import { i18n } from "discourse-i18n";
 import { resetCurrentReaction } from "discourse/plugins/discourse-reactions/discourse/widgets/discourse-reactions-actions";
 import ReactionsActionButton from "../components/discourse-reactions-actions-button";
@@ -129,14 +130,12 @@ function initializeDiscourseReactions(api) {
           const count = this.notification.data.count;
           const nameOrUsername = this.siteSettings.prioritize_full_name_in_ux
             ? this.notification.data.display_name
-            : this.notification.data.display_username;
+            : this.username;
 
           if (!count || count === 1 || !this.notification.data.username2) {
             return nameOrUsername;
           }
           if (count > 2) {
-            console.log("OVER TWO REACTIONS!!!!!!!!!");
-            console.log(nameOrUsername);
             return i18n("notifications.reaction_multiple_users", {
               username: nameOrUsername,
               count: count - 1,
@@ -144,7 +143,7 @@ function initializeDiscourseReactions(api) {
           } else {
             const nameOrUsername2 = this.siteSettings.prioritize_full_name_in_ux
               ? this.notification.data.name2
-              : this.notification.data.username2;
+              : formatUsername(this.notification.data.username2);
             return i18n("notifications.reaction_2_users", {
               username: nameOrUsername,
               username2: nameOrUsername2,

--- a/assets/javascripts/discourse/initializers/discourse-reactions.gjs
+++ b/assets/javascripts/discourse/initializers/discourse-reactions.gjs
@@ -3,7 +3,6 @@ import { replaceIcon } from "discourse/lib/icon-library";
 import { withPluginApi } from "discourse/lib/plugin-api";
 import { emojiUrlFor } from "discourse/lib/text";
 import { userPath } from "discourse/lib/url";
-import { formatUsername } from "discourse/lib/utilities";
 import { i18n } from "discourse-i18n";
 import { resetCurrentReaction } from "discourse/plugins/discourse-reactions/discourse/widgets/discourse-reactions-actions";
 import ReactionsActionButton from "../components/discourse-reactions-actions-button";

--- a/assets/javascripts/discourse/widgets/discourse-reactions-list-emoji.js
+++ b/assets/javascripts/discourse/widgets/discourse-reactions-list-emoji.js
@@ -45,7 +45,7 @@ export default createWidget("discourse-reactions-list-emoji", {
           !this.siteSettings.prioritize_username_in_ux &&
           this.siteSettings.prioritize_full_name_in_ux
         ) {
-          displayName = user.name;
+          displayName = user.name || user.username;
         } else if (this.siteSettings.prioritize_username_in_ux) {
           displayName = user.username;
         } else if (!user.name) {

--- a/assets/javascripts/discourse/widgets/discourse-reactions-list-emoji.js
+++ b/assets/javascripts/discourse/widgets/discourse-reactions-list-emoji.js
@@ -41,7 +41,12 @@ export default createWidget("discourse-reactions-list-emoji", {
     } else {
       users.slice(0, DISPLAY_MAX_USERS).forEach((user) => {
         let displayName;
-        if (this.siteSettings.prioritize_username_in_ux) {
+        if (
+          !this.siteSettings.prioritize_username_in_ux &&
+          this.siteSettings.prioritize_full_name_in_ux
+        ) {
+          displayName = user.name;
+        } else if (this.siteSettings.prioritize_username_in_ux) {
           displayName = user.username;
         } else if (!user.name) {
           displayName = user.username;

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -28,24 +28,5 @@ en:
       reaction_multiple_users:
         one: "%{username} and %{count} other"
         other: "%{username} and %{count} others"
-      reaction:
-        single: "<span>%{username}</span> %{description}"
-        multiple: "<span>%{username}</span> reacted to %{count} of your posts"
-      reaction_2: "<span class='double-user'>%{username}, %{username2}</span> %{description}"
-      reaction_many:
-        one: "<span class='multi-user'>%{username} and %{count} other</span> %{description}"
-        other: "<span class='multi-user'>%{username} and %{count} others</span> %{description}"
       titles:
         reaction: "new reaction"
-      fullname:
-        reaction_2_users: "%{fullname}, %{fullname2}"
-        reaction_multiple_users:
-          one: "%{fullname} and %{count} other"
-          other: "%{fullname} and %{count} others"
-        reaction:
-          single: "<span>%{fullname}</span> %{description}"
-          multiple: "<span>%{fullname}</span> reacted to %{count} of your posts"
-        reaction_2: "<span class='double-user'>%{fullname}, %{fullname2}</span> %{description}"
-        reaction_many:
-          one: "<span class='multi-user'>%{fullname} and %{count} other</span> %{description}"
-          other: "<span class='multi-user'>%{fullname} and %{count} others</span> %{description}"

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -37,3 +37,15 @@ en:
         other: "<span class='multi-user'>%{username} and %{count} others</span> %{description}"
       titles:
         reaction: "new reaction"
+      fullname:
+        reaction_2_users: "%{fullname}, %{fullname2}"
+        reaction_multiple_users:
+          one: "%{fullname} and %{count} other"
+          other: "%{fullname} and %{count} others"
+        reaction:
+          single: "<span>%{fullname}</span> %{description}"
+          multiple: "<span>%{fullname}</span> reacted to %{count} of your posts"
+        reaction_2: "<span class='double-user'>%{fullname}, %{fullname2}</span> %{description}"
+        reaction_many:
+          one: "<span class='multi-user'>%{fullname} and %{count} other</span> %{description}"
+          other: "<span class='multi-user'>%{fullname} and %{count} others</span> %{description}"

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -30,3 +30,15 @@ en:
         other: "%{username} and %{count} others"
       titles:
         reaction: "new reaction"
+      fullname:
+        reaction_2_users: "%{fullname}, %{fullname2}"
+        reaction_multiple_users:
+          one: "%{fullname} and %{count} other"
+          other: "%{fullname} and %{count} others"
+        reaction:
+          single: "<span>%{fullname}</span> %{description}"
+          multiple: "<span>%{fullname}</span> reacted to %{count} of your posts"
+        reaction_2: "<span class='double-user'>%{fullname}, %{fullname2}</span> %{description}"
+        reaction_many:
+          one: "<span class='multi-user'>%{fullname} and %{count} other</span> %{description}"
+          other: "<span class='multi-user'>%{fullname} and %{count} others</span> %{description}"

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -30,15 +30,3 @@ en:
         other: "%{username} and %{count} others"
       titles:
         reaction: "new reaction"
-      fullname:
-        reaction_2_users: "%{fullname}, %{fullname2}"
-        reaction_multiple_users:
-          one: "%{fullname} and %{count} other"
-          other: "%{fullname} and %{count} others"
-        reaction:
-          single: "<span>%{fullname}</span> %{description}"
-          multiple: "<span>%{fullname}</span> reacted to %{count} of your posts"
-        reaction_2: "<span class='double-user'>%{fullname}, %{fullname2}</span> %{description}"
-        reaction_many:
-          one: "<span class='multi-user'>%{fullname} and %{count} other</span> %{description}"
-          other: "<span class='multi-user'>%{fullname} and %{count} others</span> %{description}"

--- a/plugin.rb
+++ b/plugin.rb
@@ -313,7 +313,11 @@ after_initialize do
         set_data_blk:
           Proc.new do |notification|
             data = notification.data_hash
-            data.merge(username: data[:display_username], consolidated: true)
+            data.merge(
+              username: data[:display_username],
+              name: data[:display_name],
+              consolidated: true,
+            )
           end,
       )
       .set_precondition(precondition_blk: Proc.new { |data| data[:username2].blank? })
@@ -366,6 +370,7 @@ after_initialize do
                 data.merge(
                   previous_notification_id: existing_notification_of_same_type.id,
                   username2: same_type_data[:display_username],
+                  fullname2: same_type_data[:display_name],
                   count: (same_type_data[:count] || 1).to_i + 1,
                 )
 

--- a/plugin.rb
+++ b/plugin.rb
@@ -353,7 +353,7 @@ after_initialize do
       .set_mutations(
         set_data_blk:
           Proc.new do |notification|
-            existing_notification_of_same_type =
+            existing_notification_of_same_type = # the answer I want is in this section, but I can't seem to get into this object!
               Notification
                 .where(user: notification.user)
                 .order("notifications.id DESC")

--- a/plugin.rb
+++ b/plugin.rb
@@ -353,7 +353,7 @@ after_initialize do
       .set_mutations(
         set_data_blk:
           Proc.new do |notification|
-            existing_notification_of_same_type = # the answer I want is in this section, but I can't seem to get into this object!
+            existing_notification_of_same_type =
               Notification
                 .where(user: notification.user)
                 .order("notifications.id DESC")

--- a/plugin.rb
+++ b/plugin.rb
@@ -370,7 +370,7 @@ after_initialize do
                 data.merge(
                   previous_notification_id: existing_notification_of_same_type.id,
                   username2: same_type_data[:display_username],
-                  fullname2: same_type_data[:display_name],
+                  name2: same_type_data[:display_name],
                   count: (same_type_data[:count] || 1).to_i + 1,
                 )
 

--- a/spec/fabricators/reaction_notification_fabricator.rb
+++ b/spec/fabricators/reaction_notification_fabricator.rb
@@ -12,6 +12,7 @@ Fabricator(:one_reaction_notification, from: :notification) do
       original_post_id: attrs[:post].id,
       original_post_type: attrs[:post].post_type,
       original_username: acting_user.username,
+      display_name: acting_user.name,
       revision_number: nil,
       display_username: acting_user.username,
     }.to_json
@@ -31,8 +32,10 @@ Fabricator(:multiple_reactions_notification, from: :one_reaction_notification) d
       original_username: acting_user_2.username,
       revision_number: nil,
       display_username: acting_user_2.username,
+      display_name: acting_user_2.name,
       previous_notification_id: 2019,
       username2: acting_user.username,
+      name2: acting_user.name,
       count: attrs[:count] || 2,
     }.to_json
   end

--- a/spec/services/reaction_notification_spec.rb
+++ b/spec/services/reaction_notification_spec.rb
@@ -132,26 +132,6 @@ describe DiscourseReactions::ReactionNotification do
     expect(remaining_notification.data_hash[:reaction_icon]).to be_nil
   end
 
-  describe "when prioritize full name setting is on" do
-    let!(:cry_p1) { Fabricate(:reaction, post: post_1, reaction_value: "cry") }
-
-    before { SiteSetting.prioritize_full_name_in_ux = true }
-    # all specs pass except this one
-    it "displays the full name" do
-      described_class.new(cry_p1, user_2).create
-
-      expect(
-        Notification.where(
-          notification_type: Notification.types[:reaction],
-          user: post_1.user,
-        ).count,
-      ).to eq(1)
-
-      notification = Notification.where(notification_type: Notification.types[:reaction]).last
-      expect(notification.data_hash[:name]).to eq(user_2.name)
-    end
-  end
-
   describe "consolidating reaction notifications" do
     fab!(:post_2) { Fabricate(:post, user: post_1.user) }
     let!(:cry_p1) { Fabricate(:reaction, post: post_1, reaction_value: "cry") }

--- a/spec/services/reaction_notification_spec.rb
+++ b/spec/services/reaction_notification_spec.rb
@@ -135,7 +135,7 @@ describe DiscourseReactions::ReactionNotification do
       ).to eq(1)
 
       notification = Notification.where(notification_type: Notification.types[:reaction]).last
-      expect(notification.data_hash[:name]).to eq(true)
+      expect(notification.data_hash[:name]).to eq(user_2.name)
     end
   end
 

--- a/spec/services/reaction_notification_spec.rb
+++ b/spec/services/reaction_notification_spec.rb
@@ -132,6 +132,26 @@ describe DiscourseReactions::ReactionNotification do
     expect(remaining_notification.data_hash[:reaction_icon]).to be_nil
   end
 
+  describe "when prioritize full name setting is on" do
+    let!(:cry_p1) { Fabricate(:reaction, post: post_1, reaction_value: "cry") }
+
+    before { SiteSetting.prioritize_full_name_in_ux = true }
+    # all specs pass except this one
+    it "displays the full name" do
+      described_class.new(cry_p1, user_2).create
+
+      expect(
+        Notification.where(
+          notification_type: Notification.types[:reaction],
+          user: post_1.user,
+        ).count,
+      ).to eq(1)
+
+      notification = Notification.where(notification_type: Notification.types[:reaction]).last
+      expect(notification.data_hash[:name]).to eq(true)
+    end
+  end
+
   describe "consolidating reaction notifications" do
     fab!(:post_2) { Fabricate(:post, user: post_1.user) }
     let!(:cry_p1) { Fabricate(:reaction, post: post_1, reaction_value: "cry") }

--- a/spec/services/reaction_notification_spec.rb
+++ b/spec/services/reaction_notification_spec.rb
@@ -90,6 +90,8 @@ describe DiscourseReactions::ReactionNotification do
   end
 
   it "displays the full name" do
+    cry_p1 = Fabricate(:reaction, post: post_1, reaction_value: "cry")
+
     described_class.new(cry_p1, user_2).create
 
     expect(

--- a/spec/services/reaction_notification_spec.rb
+++ b/spec/services/reaction_notification_spec.rb
@@ -148,7 +148,7 @@ describe DiscourseReactions::ReactionNotification do
       ).to eq(1)
 
       notification = Notification.where(notification_type: Notification.types[:reaction]).last
-      expect(notification.data_hash[:name]).to eq(true)
+      expect(notification.data_hash[:name]).to eq(user_2.name)
     end
   end
 

--- a/spec/services/reaction_notification_spec.rb
+++ b/spec/services/reaction_notification_spec.rb
@@ -119,6 +119,26 @@ describe DiscourseReactions::ReactionNotification do
     expect(remaining_notification.data_hash[:reaction_icon]).to be_nil
   end
 
+  describe "when prioritize full name setting is on" do
+    let!(:cry_p1) { Fabricate(:reaction, post: post_1, reaction_value: "cry") }
+
+    before { SiteSetting.prioritize_full_name_in_ux = true }
+    # all specs pass except this one
+    it "displays the full name" do
+      described_class.new(cry_p1, user_2).create
+
+      expect(
+        Notification.where(
+          notification_type: Notification.types[:reaction],
+          user: post_1.user,
+        ).count,
+      ).to eq(1)
+
+      notification = Notification.where(notification_type: Notification.types[:reaction]).last
+      expect(notification.data_hash[:name]).to eq(true)
+    end
+  end
+
   describe "consolidating reaction notifications" do
     fab!(:post_2) { Fabricate(:post, user: post_1.user) }
     let!(:cry_p1) { Fabricate(:reaction, post: post_1, reaction_value: "cry") }

--- a/spec/system/reaction_notifications_spec.rb
+++ b/spec/system/reaction_notifications_spec.rb
@@ -88,6 +88,7 @@ describe "Reactions | Notifications", type: :system, js: true do
           username2: acting_user_1.name,
         ),
       )
+
       expect(labels[2]).to have_text(acting_user_1.name)
     end
   end

--- a/spec/system/reaction_notifications_spec.rb
+++ b/spec/system/reaction_notifications_spec.rb
@@ -65,6 +65,17 @@ describe "Reactions | Notifications", type: :system, js: true do
   end
 
   context "when prioritize full names in ux site setting is on" do
+    fab!(:acting_user_3) { Fabricate(:user, username: "missingno", name: nil) }
+    fab!(:null_name_notification) do
+      Fabricate(
+        :multiple_reactions_notification,
+        user: current_user,
+        count: 2,
+        acting_user: acting_user_3,
+        acting_user_2: acting_user_2,
+      )
+    end
+
     before { SiteSetting.prioritize_full_name_in_ux = true }
 
     it "renders reaction notifications with full names" do
@@ -73,11 +84,11 @@ describe "Reactions | Notifications", type: :system, js: true do
 
       labels = page.all("#quick-access-all-notifications .notification.reaction .item-label")
 
-      expect(labels[0]).to have_text(
+      expect(labels[1]).to have_text(
         I18n.t("js.notifications.reaction_multiple_users", username: acting_user_2.name, count: 2),
       )
 
-      expect(labels[1]).to have_text(
+      expect(labels[2]).to have_text(
         I18n.t(
           "js.notifications.reaction_2_users",
           username: acting_user_2.name,
@@ -86,6 +97,7 @@ describe "Reactions | Notifications", type: :system, js: true do
       )
 
       expect(labels[2]).to have_text(acting_user_1.name)
+      expect(labels[0]).to have_text(acting_user_3.username)
     end
   end
 end

--- a/spec/system/reaction_notifications_spec.rb
+++ b/spec/system/reaction_notifications_spec.rb
@@ -2,8 +2,8 @@
 
 describe "Reactions | Notifications", type: :system, js: true do
   fab!(:current_user) { Fabricate(:user) }
-  fab!(:acting_user_1) { Fabricate(:user) }
-  fab!(:acting_user_2) { Fabricate(:user) }
+  fab!(:acting_user_1) { Fabricate(:user, name: "Bruce Wayne I") }
+  fab!(:acting_user_2) { Fabricate(:user, name: "Bruce Wayne II") }
 
   fab!(:one_reaction_notification) do
     Fabricate(:one_reaction_notification, user: current_user, acting_user: acting_user_1)
@@ -65,11 +65,7 @@ describe "Reactions | Notifications", type: :system, js: true do
   end
 
   context "when prioritize full names in ux site setting is on" do
-    before do
-      SiteSetting.prioritize_full_name_in_ux = true
-      SiteSetting.discourse_reactions_enabled = true
-      sign_in(current_user)
-    end
+    before { SiteSetting.prioritize_full_name_in_ux = true }
 
     it "renders reaction notifications with full names" do
       visit("/")

--- a/spec/system/reaction_notifications_spec.rb
+++ b/spec/system/reaction_notifications_spec.rb
@@ -63,4 +63,36 @@ describe "Reactions | Notifications", type: :system, js: true do
     )
     expect(labels[2]).to have_text(acting_user_1.username)
   end
+
+  context "when prioritize full names in ux site setting is on" do
+    before do
+      SiteSetting.prioritize_full_name_in_ux = true
+      SiteSetting.discourse_reactions_enabled = true
+      sign_in(current_user)
+    end
+
+    it "renders reaction notifications with full names" do
+      visit("/")
+      user_menu.open
+
+      labels = page.all("#quick-access-all-notifications .notification.reaction .item-label")
+
+      expect(labels[0]).to have_text(
+        I18n.t(
+          "js.notifications.fullname.reaction_multiple_users.one",
+          fullname: acting_user_2.name,
+          count: 2,
+        ),
+      )
+
+      expect(labels[1]).to have_text(
+        I18n.t(
+          "js.notifications.fullname.reaction_2_users",
+          fullname: acting_user_2.name,
+          fullname2: acting_user_1.name,
+        ),
+      )
+      expect(labels[2]).to have_text(acting_user_1.username)
+    end
+  end
 end

--- a/spec/system/reaction_notifications_spec.rb
+++ b/spec/system/reaction_notifications_spec.rb
@@ -78,21 +78,17 @@ describe "Reactions | Notifications", type: :system, js: true do
       labels = page.all("#quick-access-all-notifications .notification.reaction .item-label")
 
       expect(labels[0]).to have_text(
-        I18n.t(
-          "js.notifications.reaction_multiple_users.one",
-          fullname: acting_user_2.name,
-          count: 2,
-        ),
+        I18n.t("js.notifications.reaction_multiple_users", username: acting_user_2.name, count: 2),
       )
 
       expect(labels[1]).to have_text(
         I18n.t(
           "js.notifications.reaction_2_users",
-          fullname: acting_user_2.name,
-          fullname2: acting_user_1.name,
+          username: acting_user_2.name,
+          username2: acting_user_1.name,
         ),
       )
-      expect(labels[2]).to have_text(acting_user_1.username)
+      expect(labels[2]).to have_text(acting_user_1.name)
     end
   end
 end

--- a/spec/system/reaction_notifications_spec.rb
+++ b/spec/system/reaction_notifications_spec.rb
@@ -79,7 +79,7 @@ describe "Reactions | Notifications", type: :system, js: true do
 
       expect(labels[0]).to have_text(
         I18n.t(
-          "js.notifications.fullname.reaction_multiple_users.one",
+          "js.notifications.reaction_multiple_users.one",
           fullname: acting_user_2.name,
           count: 2,
         ),
@@ -87,7 +87,7 @@ describe "Reactions | Notifications", type: :system, js: true do
 
       expect(labels[1]).to have_text(
         I18n.t(
-          "js.notifications.fullname.reaction_2_users",
+          "js.notifications.reaction_2_users",
           fullname: acting_user_2.name,
           fullname2: acting_user_1.name,
         ),

--- a/spec/system/reaction_notifications_spec.rb
+++ b/spec/system/reaction_notifications_spec.rb
@@ -97,6 +97,13 @@ describe "Reactions | Notifications", type: :system, js: true do
       )
 
       expect(labels[2]).to have_text(acting_user_1.name)
+    end
+
+    it "falls back to the username when name field is nil" do
+      visit("/")
+      user_menu.open
+
+      labels = page.all("#quick-access-all-notifications .notification.reaction .item-label")
       expect(labels[0]).to have_text(acting_user_3.username)
     end
   end

--- a/test/javascripts/acceptance/discourse-reactions-notifications-test.js
+++ b/test/javascripts/acceptance/discourse-reactions-notifications-test.js
@@ -241,3 +241,179 @@ acceptance("Discourse Reactions - Notifications", function (needs) {
     );
   });
 });
+
+acceptance(
+  "Discourse Reactions - Notifications | Full Name Setting On",
+  function (needs) {
+    needs.user({ redesigned_user_menu_enabled: true });
+
+    needs.settings({
+      discourse_reactions_enabled: true,
+      discourse_reactions_enabled_reactions: "otter|open_mouth",
+      discourse_reactions_reaction_for_like: "heart",
+      discourse_reactions_like_icon: "heart",
+      prioritize_full_name_in_ux: true,
+    });
+
+    needs.pretender((server, helper) => {
+      server.get("/notifications", () => {
+        return helper.response({
+          notifications: [
+            {
+              id: 1334,
+              user_id: 88,
+              notification_type: 25,
+              read: true,
+              high_priority: false,
+              created_at: "2022-08-18T13:00:11.166Z",
+              post_number: 12,
+              topic_id: 8432,
+              fancy_title: "Topic with one reaction from a user",
+              slug: "topic-with-one-reaction-from-a-user",
+              data: {
+                topic_title: "Topic with one reaction from a user",
+                original_post_id: 3349,
+                original_post_type: 1,
+                original_username: "krus",
+                revision_number: null,
+                display_username: "krus",
+                display_name: "Brucer Wayner II",
+                reaction_icon: "heart",
+                previous_notification_id: 933,
+                count: 1,
+              },
+            },
+            {
+              id: 842,
+              user_id: 88,
+              notification_type: 25,
+              read: true,
+              high_priority: false,
+              created_at: "2021-08-19T23:00:11.166Z",
+              post_number: 3,
+              topic_id: 138,
+              fancy_title: "Topic with 2 likes (total) from 2 users",
+              slug: "topic-with-2-likes-total-from-2-users",
+              data: {
+                topic_title: "Topic with 2 likes (total) from 2 users",
+                original_post_id: 443,
+                original_post_type: 1,
+                original_username: "jammed-radio",
+                revision_number: null,
+                display_username: "jammed-radio",
+                display_name: "Bruce Wayne I",
+                previous_notification_id: 933,
+                username2: "broken-radio",
+                name2: "Brucer Wayner II",
+                reaction_icon: "heart",
+                count: 2,
+              },
+            },
+            {
+              id: 3843,
+              user_id: 88,
+              notification_type: 25,
+              read: true,
+              high_priority: false,
+              created_at: "2021-08-19T23:00:11.166Z",
+              post_number: 31,
+              topic_id: 832,
+              fancy_title: "Topic with likes from multiple users",
+              slug: "topic-with-likes-from-multiple-users",
+              data: {
+                topic_title: "Topic with likes from multiple users",
+                original_post_id: 903,
+                original_post_type: 1,
+                original_username: "jam-and-cheese",
+                revision_number: null,
+                display_username: "jam-and-cheese",
+                name: "Pickles McGee",
+                previous_notification_id: 933,
+                username2: "cheesy-monkey",
+                name2: "Hamburger Patty",
+                reaction_icon: "heart",
+                count: 3,
+              },
+            },
+            {
+              id: 2189,
+              user_id: 88,
+              notification_type: 25,
+              read: true,
+              high_priority: false,
+              created_at: "2020-11-13T03:10:41.166Z",
+              post_number: 31,
+              topic_id: 913,
+              fancy_title: "Topic with likes and reactions",
+              slug: "topic-with-likes-and-reactions",
+              data: {
+                topic_title: "Topic with likes and reactions",
+                original_post_id: 384,
+                original_post_type: 1,
+                original_username: "nuclear-reactor",
+                revision_number: null,
+                display_username: "nuclear-reactor",
+                display_name: "Monkey D. Luffy",
+                previous_notification_id: 933,
+                username2: "solar-engine",
+                name2: "Roronoa Zoro",
+                count: 4,
+              },
+            },
+            {
+              id: 7731,
+              user_id: 88,
+              notification_type: 25,
+              read: true,
+              high_priority: false,
+              created_at: "2022-07-18T10:00:11.186Z",
+              post_number: null,
+              topic_id: null,
+              fancy_title: null,
+              slug: null,
+              data: {
+                topic_title: "Double reactions on multiple posts from one user",
+                original_post_id: 843,
+                original_post_type: 1,
+                original_username: "johnny",
+                revision_number: null,
+                display_username: "johnny",
+                username: "johnny",
+                consolidated: true,
+                count: 2,
+              },
+            },
+          ],
+        });
+      });
+    });
+
+    test("reaction notifications with full name site setting on", async (assert) => {
+      await visit("/");
+      await click(".d-header-icons .current-user button");
+
+      const notifications = queryAll(
+        "#quick-access-all-notifications ul li.notification.reaction a"
+      );
+
+      assert.strictEqual(
+        notifications[1].textContent.replaceAll(/\s+/g, " ").trim(),
+        `${i18n("notifications.reaction_2_users", {
+          username: "Bruce Wayne I",
+          username2: "Brucer Wayner II",
+        })} Topic with 2 likes (total) from 2 users`,
+        "notification for 2 likes from 2 users has the right content"
+      );
+
+      // this one isn't receiving username value for the translation for some reason - solution should also fix the rails test error
+      assert.strictEqual(
+        notifications[2].textContent.replaceAll(/\s+/g, " ").trim(),
+        `${i18n("notifications.reaction_multiple_users", {
+          username: "Monkey D. Luffy",
+          count: 3,
+        })} Topic with likes and reactions`,
+        "notification for reactions from 3 or more users has the right content"
+      );
+    });
+  }
+);

--- a/test/javascripts/acceptance/discourse-reactions-notifications-test.js
+++ b/test/javascripts/acceptance/discourse-reactions-notifications-test.js
@@ -310,32 +310,6 @@ acceptance(
               },
             },
             {
-              id: 3843,
-              user_id: 88,
-              notification_type: 25,
-              read: true,
-              high_priority: false,
-              created_at: "2021-08-19T23:00:11.166Z",
-              post_number: 31,
-              topic_id: 832,
-              fancy_title: "Topic with likes from multiple users",
-              slug: "topic-with-likes-from-multiple-users",
-              data: {
-                topic_title: "Topic with likes from multiple users",
-                original_post_id: 903,
-                original_post_type: 1,
-                original_username: "jam-and-cheese",
-                revision_number: null,
-                display_username: "jam-and-cheese",
-                name: "Pickles McGee",
-                previous_notification_id: 933,
-                username2: "cheesy-monkey",
-                name2: "Hamburger Patty",
-                reaction_icon: "heart",
-                count: 3,
-              },
-            },
-            {
               id: 2189,
               user_id: 88,
               notification_type: 25,
@@ -360,29 +334,6 @@ acceptance(
                 count: 4,
               },
             },
-            {
-              id: 7731,
-              user_id: 88,
-              notification_type: 25,
-              read: true,
-              high_priority: false,
-              created_at: "2022-07-18T10:00:11.186Z",
-              post_number: null,
-              topic_id: null,
-              fancy_title: null,
-              slug: null,
-              data: {
-                topic_title: "Double reactions on multiple posts from one user",
-                original_post_id: 843,
-                original_post_type: 1,
-                original_username: "johnny",
-                revision_number: null,
-                display_username: "johnny",
-                username: "johnny",
-                consolidated: true,
-                count: 2,
-              },
-            },
           ],
         });
       });
@@ -405,7 +356,6 @@ acceptance(
         "notification for 2 likes from 2 users has the right content"
       );
 
-      // this one isn't receiving username value for the translation for some reason - solution should also fix the rails test error
       assert.strictEqual(
         notifications[2].textContent.replaceAll(/\s+/g, " ").trim(),
         `${i18n("notifications.reaction_multiple_users", {

--- a/test/javascripts/acceptance/discourse-reactions-notifications-test.js
+++ b/test/javascripts/acceptance/discourse-reactions-notifications-test.js
@@ -4,7 +4,7 @@ import { acceptance, queryAll } from "discourse/tests/helpers/qunit-helpers";
 import { i18n } from "discourse-i18n";
 
 acceptance("Discourse Reactions - Notifications", function (needs) {
-  needs.user({ redesigned_user_menu_enabled: true });
+  needs.user();
 
   needs.settings({
     discourse_reactions_enabled: true,
@@ -245,7 +245,7 @@ acceptance("Discourse Reactions - Notifications", function (needs) {
 acceptance(
   "Discourse Reactions - Notifications | Full Name Setting On",
   function (needs) {
-    needs.user({ redesigned_user_menu_enabled: true });
+    needs.user();
 
     needs.settings({
       discourse_reactions_enabled: true,

--- a/test/javascripts/acceptance/discourse-reactions-notifications-test.js
+++ b/test/javascripts/acceptance/discourse-reactions-notifications-test.js
@@ -323,29 +323,9 @@ acceptance(
         .dom("li.notification.reaction:nth-child(1) a")
         .hasText(/Bruce Wayne I, Brucer Wayner II/);
 
-<<<<<<< HEAD
       assert
         .dom("li.notification.reaction:nth-child(2) a")
         .hasText(/Monkey D. Luffy and 3 others/);
-=======
-      assert.strictEqual(
-        notifications[1].textContent.replaceAll(/\s+/g, " ").trim(),
-        `${i18n("notifications.reaction_2_users", {
-          username: "Bruce Wayne I",
-          username2: "Brucer Wayner II",
-        })} Topic with 2 likes (total) from 2 users`,
-        "notification for 2 likes from 2 users has the right content"
-      );
-
-      assert.strictEqual(
-        notifications[2].textContent.replaceAll(/\s+/g, " ").trim(),
-        `${i18n("notifications.reaction_multiple_users", {
-          username: "Monkey D. Luffy",
-          count: 3,
-        })} Topic with likes and reactions`,
-        "notification for reactions from 3 or more users has the right content"
-      );
->>>>>>> 2a07f6f (Last bit of spec fixes)
     });
   }
 );

--- a/test/javascripts/acceptance/discourse-reactions-notifications-test.js
+++ b/test/javascripts/acceptance/discourse-reactions-notifications-test.js
@@ -323,9 +323,29 @@ acceptance(
         .dom("li.notification.reaction:nth-child(1) a")
         .hasText(/Bruce Wayne I, Brucer Wayner II/);
 
+<<<<<<< HEAD
       assert
         .dom("li.notification.reaction:nth-child(2) a")
         .hasText(/Monkey D. Luffy and 3 others/);
+=======
+      assert.strictEqual(
+        notifications[1].textContent.replaceAll(/\s+/g, " ").trim(),
+        `${i18n("notifications.reaction_2_users", {
+          username: "Bruce Wayne I",
+          username2: "Brucer Wayner II",
+        })} Topic with 2 likes (total) from 2 users`,
+        "notification for 2 likes from 2 users has the right content"
+      );
+
+      assert.strictEqual(
+        notifications[2].textContent.replaceAll(/\s+/g, " ").trim(),
+        `${i18n("notifications.reaction_multiple_users", {
+          username: "Monkey D. Luffy",
+          count: 3,
+        })} Topic with likes and reactions`,
+        "notification for reactions from 3 or more users has the right content"
+      );
+>>>>>>> 2a07f6f (Last bit of spec fixes)
     });
   }
 );

--- a/test/javascripts/acceptance/discourse-reactions-notifications-test.js
+++ b/test/javascripts/acceptance/discourse-reactions-notifications-test.js
@@ -260,30 +260,6 @@ acceptance(
         return helper.response({
           notifications: [
             {
-              id: 1334,
-              user_id: 88,
-              notification_type: 25,
-              read: true,
-              high_priority: false,
-              created_at: "2022-08-18T13:00:11.166Z",
-              post_number: 12,
-              topic_id: 8432,
-              fancy_title: "Topic with one reaction from a user",
-              slug: "topic-with-one-reaction-from-a-user",
-              data: {
-                topic_title: "Topic with one reaction from a user",
-                original_post_id: 3349,
-                original_post_type: 1,
-                original_username: "krus",
-                revision_number: null,
-                display_username: "krus",
-                display_name: "Brucer Wayner II",
-                reaction_icon: "heart",
-                previous_notification_id: 933,
-                count: 1,
-              },
-            },
-            {
               id: 842,
               user_id: 88,
               notification_type: 25,
@@ -339,31 +315,17 @@ acceptance(
       });
     });
 
-    test("reaction notifications with full name site setting on", async (assert) => {
+    test("reaction notifications with full name site setting on", async function (assert) {
       await visit("/");
       await click(".d-header-icons .current-user button");
 
-      const notifications = queryAll(
-        "#quick-access-all-notifications ul li.notification.reaction a"
-      );
+      assert
+        .dom("li.notification.reaction:nth-child(1) a")
+        .hasText(/Bruce Wayne I, Brucer Wayner II/);
 
-      assert.strictEqual(
-        notifications[1].textContent.replaceAll(/\s+/g, " ").trim(),
-        `${i18n("notifications.reaction_2_users", {
-          username: "Bruce Wayne I",
-          username2: "Brucer Wayner II",
-        })} Topic with 2 likes (total) from 2 users`,
-        "notification for 2 likes from 2 users has the right content"
-      );
-
-      assert.strictEqual(
-        notifications[2].textContent.replaceAll(/\s+/g, " ").trim(),
-        `${i18n("notifications.reaction_multiple_users", {
-          username: "Monkey D. Luffy",
-          count: 3,
-        })} Topic with likes and reactions`,
-        "notification for reactions from 3 or more users has the right content"
-      );
+      assert
+        .dom("li.notification.reaction:nth-child(2) a")
+        .hasText(/Monkey D. Luffy and 3 others/);
     });
   }
 );


### PR DESCRIPTION
Equivalent core PR [here](https://github.com/discourse/discourse/pull/30583).

Ensures full names get passed through if the hidden `prioritize_full_name_in_ux` setting is `true`.

Before (with setting on):
![Screenshot 2025-02-12 at 12 04 39 PM](https://github.com/user-attachments/assets/baea7193-581a-44ed-a88b-6e59f7c38d6b)
![Screenshot 2025-02-12 at 12 07 02 PM](https://github.com/user-attachments/assets/88617663-f043-455b-ad51-fb26d9fcb167)



After (with setting on):
![Screenshot 2025-02-12 at 12 02 43 PM](https://github.com/user-attachments/assets/2e4c5d29-d317-49ee-b136-9120ea114e4d)
![Screenshot 2025-02-12 at 12 06 16 PM](https://github.com/user-attachments/assets/a577f3a9-115f-4256-8af5-bc79dd245750)
