### PR TITLE
UX: fix reaction alignment in user stream items

### DIFF
--- a/assets/stylesheets/desktop/discourse-reactions.scss
+++ b/assets/stylesheets/desktop/discourse-reactions.scss
@@ -7,4 +7,8 @@
   nav.post-controls .show-replies {
     position: relative;
   }
+
+  .discourse-reactions-my-reaction {
+    margin: 0.75em 0 0 3.5em;
+  }
 }


### PR DESCRIPTION
Fixes the desktop alignment of reaction emojis following changes in [#31122](https://github.com/discourse/discourse/pull/31122) in core.

Before:

<img width="533" alt="Screenshot 2025-02-07 at 3 15 51 PM" src="https://github.com/user-attachments/assets/9599fa75-55c7-45f0-b9bb-39eb23bbf856" />

After:

<img width="511" alt="Screenshot 2025-02-07 at 3 16 09 PM" src="https://github.com/user-attachments/assets/f97f5330-ad3c-413f-8197-744fd1a47b44" />
