### PR TITLE
FIX: prevents panel to close on mobile

### DIFF
--- a/assets/javascripts/discourse/widgets/discourse-reactions-counter.js
+++ b/assets/javascripts/discourse/widgets/discourse-reactions-counter.js
@@ -177,11 +177,19 @@ export default createWidget("discourse-reactions-counter", {
     }
   },
 
-  pointerOver() {
+  pointerOver(event) {
+    if (event.pointerType !== "mouse") {
+      return;
+    }
+
     this.callWidgetFunction("cancelCollapse");
   },
 
   pointerOut(event) {
+    if (event.pointerType !== "mouse") {
+      return;
+    }
+
     if (!event.relatedTarget?.closest(`#${this.buildId(this.attrs)}`)) {
       this.callWidgetFunction("scheduleCollapse", "collapseStatePanel");
     }


### PR DESCRIPTION
Due to a recent change to use pointerOver/pointerOut we were collapsing the panel after a touch as it would call pointerOut and relatedTarget is undefined in this case which would have always called `scheduleCollapse`.