### PR TITLE
UX: apply optional core border-radius to button

### DIFF
--- a/assets/stylesheets/common/discourse-reactions.scss
+++ b/assets/stylesheets/common/discourse-reactions.scss
@@ -431,6 +431,7 @@ html.discourse-reactions-no-select {
 
 .discourse-reactions-double-button {
   display: inline-flex;
+  border-radius: var(--d-post-control-border-radius);
 
   @include user-select(none);
 }


### PR DESCRIPTION
This adds the optional border-radius variable for themes (matches core) 

Before:
![image](https://github.com/user-attachments/assets/cfd8cb0e-cdce-4f66-8db4-4d4a72937163)


After (when a value is applied):
![image](https://github.com/user-attachments/assets/0617235b-68a8-4685-9e81-3b05c3fcfb93)
