### PR TITLE
UX: have discourse reaction extends to 100% height to align correctly …

### DIFF
--- a/assets/stylesheets/common/discourse-reactions.scss
+++ b/assets/stylesheets/common/discourse-reactions.scss
@@ -326,6 +326,7 @@ html.discourse-reactions-no-select {
 .discourse-reactions-actions {
   display: inline-flex;
   justify-content: flex-end;
+  height: 100%;
 
   .spinner-container {
     align-self: center;


### PR DESCRIPTION
…on post actions

Sister commit of https://github.com/discourse/discourse-solved/pull/349 