### PR TITLE
FIX: Opening user cards from reactions list

### DIFF
--- a/assets/javascripts/discourse/components/discourse-reactions-counter.gjs
+++ b/assets/javascripts/discourse/components/discourse-reactions-counter.gjs
@@ -58,6 +58,10 @@ export default class DiscourseReactionsCounter extends Component {
 
   @action
   click(event) {
+    if (event.target.closest("[data-user-card]")) {
+      return;
+    }
+
     this.args.cancelCollapse();
 
     if (!this.capabilities.touch || !this.site.mobileView) {

--- a/spec/system/page_objects/post_reactions_list.rb
+++ b/spec/system/page_objects/post_reactions_list.rb
@@ -36,6 +36,10 @@ module PageObjects
         page.has_css?(".discourse-reactions-list-emoji .user-list", visible: true)
       end
 
+      def click_reaction(reaction)
+        component.find(reaction_list_emoji_selector(reaction)).click
+      end
+
       def has_users_for_reaction?(reaction, usernames)
         find("#{reaction_list_emoji_selector(reaction)} .user-list .container").has_text?(
           usernames.join("\n"),

--- a/spec/system/reactions_post_list_spec.rb
+++ b/spec/system/reactions_post_list_spec.rb
@@ -33,8 +33,6 @@ describe "Reactions | Post reaction user list", type: :system, js: true do
         sign_in(current_user)
         visit(post.url)
 
-        page.execute_script("window.isSystemTest = true;")
-
         expect(reactions_list).to have_reaction("heart")
         expect(reactions_list).to have_reaction("clap")
 
@@ -48,6 +46,17 @@ describe "Reactions | Post reaction user list", type: :system, js: true do
         expect(reactions_list).to have_users_for_reaction("clap", [user_3.username])
       end
 
+      it "shows more info about reactions when clicking" do
+        visit(post.url)
+        expect(reactions_list).to have_reaction("heart")
+        reactions_list.click_reaction("heart")
+
+        expect(page).to have_css(".discourse-reactions-state-panel")
+        find(".discourse-reactions-state-panel [data-user-card=#{user_2.username}]").click
+
+        expect(page).to have_css(".user-card.user-card-#{user_2.username}")
+      end
+
       context "when the site allows anonymous users to like posts" do
         before do
           SiteSetting.allow_anonymous_mode = true
@@ -56,7 +65,6 @@ describe "Reactions | Post reaction user list", type: :system, js: true do
 
         it "shows a list of users who have liked a post on hover for unauthenticated users" do
           visit(post.url)
-          page.execute_script("window.isSystemTest = true;")
 
           expect(reactions_list).to have_reaction("heart")
 
@@ -68,7 +76,6 @@ describe "Reactions | Post reaction user list", type: :system, js: true do
           anonymous_user = Fabricate(:anonymous)
           sign_in(anonymous_user)
           visit(post.url)
-          page.execute_script("window.isSystemTest = true;")
 
           expect(reactions_list).to have_reaction("heart")
 


### PR DESCRIPTION
Followup to 3d7822e36369f987406bd933b8dcc86c64489523

Also removes the `window.isSystemTest =` calls, because it no longer seems to be referenced by anything.