### PR TITLE
DEV: Deprecate external_system_avatars_enabled setting

### DIFF
--- a/spec/system/reactions_activity_spec.rb
+++ b/spec/system/reactions_activity_spec.rb
@@ -28,6 +28,8 @@ describe "Reactions | Activity", type: :system, js: true do
     context "when unicode usernames is enabled " do
       before do
         SiteSetting.external_system_avatars_enabled = true
+        SiteSetting.external_system_avatars_url =
+          "/letter_avatar_proxy/v4/letter/{first_letter}/{color}/{size}.png"
         SiteSetting.unicode_usernames = true
       end
 


### PR DESCRIPTION
### What is this change?

We're removing `external_system_avatars_enabled` from core, instead relying on the presence of `external_system_avatars_url`. This plugin doesn't use it explicitly, but is testing some parts of core that are affected.

This change is required for the core change to pass plugin system tests.